### PR TITLE
Break perf energy models into multiple classes

### DIFF
--- a/libpimeval/Makefile
+++ b/libpimeval/Makefile
@@ -6,7 +6,8 @@
 CXX := g++
 CXXFLAGS := -Wall -Wextra -std=c++17
 CXXFLAGS_DEBUG := -g
-CXXFLAGS_PERF := -Ofast -DNDEBUG -Wno-unused-parameter -Wno-unused-private-field -Wno-unused-variable
+# Note: If specify -DNDEBUG, assert will be disabled
+CXXFLAGS_PERF := -Ofast -Wno-unused-parameter
 INC :=
 AR := ar
 ARFLAGS := rcs

--- a/libpimeval/src/pimCmd.cpp
+++ b/libpimeval/src/pimCmd.cpp
@@ -405,7 +405,7 @@ pimCmdCopy::updateStats() const
       numElements = m_idxEnd - m_idxBegin;
     }
     unsigned bitsPerElement = objDest.getBitsPerElement();
-    pimParamsPerf::perfEnergy mPerfEnergy = pimSim::get()->getParamsPerf()->getPerfEnergyForBytesTransfer(m_cmdType, numElements * bitsPerElement / 8);
+    pimNS::perfEnergy mPerfEnergy = pimSim::get()->getPerfEnergyModel()->getPerfEnergyForBytesTransfer(m_cmdType, numElements * bitsPerElement / 8);
     pimSim::get()->getStatsMgr()->recordCopyMainToDevice(numElements * bitsPerElement, mPerfEnergy);
 
     #if defined(DEBUG)
@@ -420,7 +420,7 @@ pimCmdCopy::updateStats() const
       numElements = m_idxEnd - m_idxBegin;
     }
     unsigned bitsPerElement = objSrc.getBitsPerElement();
-    pimParamsPerf::perfEnergy mPerfEnergy = pimSim::get()->getParamsPerf()->getPerfEnergyForBytesTransfer(m_cmdType, numElements * bitsPerElement / 8);
+    pimNS::perfEnergy mPerfEnergy = pimSim::get()->getPerfEnergyModel()->getPerfEnergyForBytesTransfer(m_cmdType, numElements * bitsPerElement / 8);
     pimSim::get()->getStatsMgr()->recordCopyDeviceToMain(numElements * bitsPerElement, mPerfEnergy);
 
     #if defined(DEBUG)
@@ -435,7 +435,7 @@ pimCmdCopy::updateStats() const
       numElements = m_idxEnd - m_idxBegin;
     }
     unsigned bitsPerElement = objSrc.getBitsPerElement();
-    pimParamsPerf::perfEnergy mPerfEnergy = pimSim::get()->getParamsPerf()->getPerfEnergyForBytesTransfer(m_cmdType, numElements * bitsPerElement / 8);
+    pimNS::perfEnergy mPerfEnergy = pimSim::get()->getPerfEnergyModel()->getPerfEnergyForBytesTransfer(m_cmdType, numElements * bitsPerElement / 8);
     pimSim::get()->getStatsMgr()->recordCopyDeviceToDevice(numElements * bitsPerElement, mPerfEnergy);
 
     #if defined(DEBUG)
@@ -538,7 +538,7 @@ pimCmdFunc1::updateStats() const
   bool isVLayout = objSrc.isVLayout();
 
   
-  pimParamsPerf::perfEnergy mPerfEnergy = pimSim::get()->getParamsPerf()->getPerfEnergyForFunc1(m_cmdType, objSrc);
+  pimNS::perfEnergy mPerfEnergy = pimSim::get()->getPerfEnergyModel()->getPerfEnergyForFunc1(m_cmdType, objSrc);
   pimSim::get()->getStatsMgr()->recordCmd(getName(dataType, isVLayout), mPerfEnergy);
   return true;
 }
@@ -712,7 +712,7 @@ pimCmdFunc2::updateStats() const
   PimDataType dataType = objSrc1.getDataType();
   bool isVLayout = objSrc1.isVLayout();
 
-  pimParamsPerf::perfEnergy mPerfEnergy = pimSim::get()->getParamsPerf()->getPerfEnergyForFunc2(m_cmdType, objSrc1);
+  pimNS::perfEnergy mPerfEnergy = pimSim::get()->getPerfEnergyModel()->getPerfEnergyForFunc2(m_cmdType, objSrc1);
   pimSim::get()->getStatsMgr()->recordCmd(getName(dataType, isVLayout), mPerfEnergy);
   return true;
 }
@@ -816,7 +816,7 @@ pimCmdRedSum<T>::updateStats() const
     numPass = objSrc.getMaxNumRegionsPerCore();
   }
 
-  pimParamsPerf::perfEnergy mPerfEnergy = pimSim::get()->getParamsPerf()->getPerfEnergyForRedSum(m_cmdType, objSrc, numPass);
+  pimNS::perfEnergy mPerfEnergy = pimSim::get()->getPerfEnergyModel()->getPerfEnergyForRedSum(m_cmdType, objSrc, numPass);
   pimSim::get()->getStatsMgr()->recordCmd(getName(dataType, isVLayout), mPerfEnergy);
   return true;
 }
@@ -883,7 +883,7 @@ pimCmdBroadcast<T>::updateStats() const
   PimDataType dataType = objDest.getDataType();
   bool isVLayout = objDest.isVLayout();
 
-  pimParamsPerf::perfEnergy mPerfEnergy = pimSim::get()->getParamsPerf()->getPerfEnergyForBroadcast(m_cmdType, objDest);
+  pimNS::perfEnergy mPerfEnergy = pimSim::get()->getPerfEnergyModel()->getPerfEnergyForBroadcast(m_cmdType, objDest);
   pimSim::get()->getStatsMgr()->recordCmd(getName(dataType, isVLayout), mPerfEnergy);
   return true;
 }
@@ -1015,7 +1015,7 @@ pimCmdRotate::updateStats() const
   PimDataType dataType = objSrc.getDataType();
   bool isVLayout = objSrc.isVLayout();
 
-  pimParamsPerf::perfEnergy mPerfEnergy = pimSim::get()->getParamsPerf()->getPerfEnergyForRotate(m_cmdType, objSrc);
+  pimNS::perfEnergy mPerfEnergy = pimSim::get()->getPerfEnergyModel()->getPerfEnergyForRotate(m_cmdType, objSrc);
   pimSim::get()->getStatsMgr()->recordCmd(getName(dataType, isVLayout), mPerfEnergy);
   return true;
 }
@@ -1042,7 +1042,7 @@ pimCmdReadRowToSa::execute()
   }
 
   // Update stats
-  pimParamsPerf::perfEnergy prfEnrgy;
+  pimNS::perfEnergy prfEnrgy;
   pimSim::get()->getStatsMgr()->recordCmd(getName(), prfEnrgy);
   return true;
 }
@@ -1068,7 +1068,7 @@ pimCmdWriteSaToRow::execute()
   }
 
   // Update stats
-  pimParamsPerf::perfEnergy prfEnrgy;
+  pimNS::perfEnergy prfEnrgy;
   pimSim::get()->getStatsMgr()->recordCmd(getName(), prfEnrgy);
   return true;
 }
@@ -1172,7 +1172,7 @@ pimCmdRRegOp::execute()
   }
 
   // Update stats
-  pimParamsPerf::perfEnergy prfEnrgy;
+  pimNS::perfEnergy prfEnrgy;
   pimSim::get()->getStatsMgr()->recordCmd(getName(), prfEnrgy);
   return true;
 }
@@ -1225,7 +1225,7 @@ pimCmdRRegRotate::execute()
   }
 
   // Update stats
-  pimParamsPerf::perfEnergy prfEnrgy;
+  pimNS::perfEnergy prfEnrgy;
   pimSim::get()->getStatsMgr()->recordCmd(getName(), prfEnrgy);
   return true;
 }
@@ -1313,7 +1313,7 @@ pimCmdAnalogAAP::execute()
   // Update stats
   std::string cmdName = getName();
   cmdName += "@" + std::to_string(m_srcRows.size()) + "," + std::to_string(m_destRows.size());
-  pimParamsPerf::perfEnergy prfEnrgy;
+  pimNS::perfEnergy prfEnrgy;
   pimSim::get()->getStatsMgr()->recordCmd(cmdName, prfEnrgy);
   return true;
 }

--- a/libpimeval/src/pimCmd.cpp
+++ b/libpimeval/src/pimCmd.cpp
@@ -795,7 +795,6 @@ pimCmdRedSum<T>::updateStats() const
   unsigned numPass = 0;
   if (m_cmdType == PimCmdEnum::REDSUM_RANGE) {
     // determine numPass for ranged redSum
-    unsigned bitsPerElement = objSrc.getBitsPerElement();
     std::unordered_map<PimCoreId, unsigned> activeRegionPerCore;
     uint64_t index = 0;
     for (const auto& region : objSrc.getRegions()) {

--- a/libpimeval/src/pimDevice.cpp
+++ b/libpimeval/src/pimDevice.cpp
@@ -32,6 +32,8 @@ pimDevice::~pimDevice()
 {
   delete m_resMgr;
   m_resMgr = nullptr;
+  delete m_perfEnergyModel;
+  m_perfEnergyModel = nullptr;
 }
 
 //! @brief  Adjust config for modeling different simulation target with same inputs
@@ -196,6 +198,8 @@ pimDevice::init(PimDeviceEnum deviceType, unsigned numRanks, unsigned numBankPer
   }
 
   m_resMgr = new pimResMgr(this);
+  pimParamsDram* paramsDram = pimSim::get()->getParamsDram();
+  m_perfEnergyModel = pimPerfEnergyFactory::getPerfEnergyModel(m_simTarget, paramsDram);
 
   m_cores.resize(m_numCores, pimCore(m_numRows, m_numCols));
 
@@ -287,6 +291,8 @@ pimDevice::init(PimDeviceEnum deviceType, const char* configFileName)
   }
 
   m_resMgr = new pimResMgr(this);
+  pimParamsDram* paramsDram = pimSim::get()->getParamsDram();
+  m_perfEnergyModel = pimPerfEnergyFactory::getPerfEnergyModel(m_simTarget, paramsDram);
   m_cores.resize(m_numCores, pimCore(m_numRows, m_numCols));
 
   std::printf("PIM-Info: Created PIM device with %u cores of %u rows and %u columns.\n", m_numCores, m_numRows, m_numCols);

--- a/libpimeval/src/pimDevice.h
+++ b/libpimeval/src/pimDevice.h
@@ -10,6 +10,7 @@
 #include "libpimeval.h"
 #include "pimCore.h"
 #include "pimCmd.h"
+#include "pimPerfEnergyModels.h"
 #ifdef DRAMSIM3_INTEG
 #include "cpu.h"
 #endif
@@ -61,6 +62,7 @@ public:
   bool pimCopyDeviceToDevice(PimObjId src, PimObjId dest, uint64_t idxBegin = 0, uint64_t idxEnd = 0);
 
   pimResMgr* getResMgr() { return m_resMgr; }
+  pimPerfEnergyBase* getPerfEnergyModel() { return m_perfEnergyModel; }
   pimCore& getCore(PimCoreId coreId) { return m_cores[coreId]; }
   bool executeCmd(std::unique_ptr<pimCmd> cmd);
 
@@ -82,6 +84,7 @@ private:
   bool m_isValid = false;
   bool m_isInit = false;
   pimResMgr* m_resMgr = nullptr;
+  pimPerfEnergyBase* m_perfEnergyModel = nullptr;
   std::vector<pimCore> m_cores;
 
 #ifdef DRAMSIM3_INTEG

--- a/libpimeval/src/pimPerfEnergyModels.cpp
+++ b/libpimeval/src/pimPerfEnergyModels.cpp
@@ -1,5 +1,5 @@
-// File: pimParamsPerf.cc
-// PIMeval Simulator - Performance parameters
+// File: pimPerfEnergyModels.cc
+// PIMeval Simulator - Performance Energy Models
 // Copyright (c) 2024 University of Virginia
 // This file is licensed under the MIT License.
 // See the LICENSE file in the root of this repository for more details.
@@ -10,8 +10,8 @@
 #include "pimPerfEnergyTables.h"
 #include <cstdio>
 
-//! @brief  pimParamsPerf ctor
-pimParamsPerf::pimParamsPerf(pimParamsDram* paramsDram)
+//! @brief  pimPerfEnergyBase ctor
+pimPerfEnergyBase::pimPerfEnergyBase(pimParamsDram* paramsDram)
   : m_paramsDram(paramsDram)
 {
   m_tR = m_paramsDram->getNsRowRead() / m_nano_to_milli;
@@ -29,8 +29,8 @@ pimParamsPerf::pimParamsPerf(pimParamsDram* paramsDram)
 }
 
 //! @brief  Get ms runtime for bytes transferred between host and device
-pimParamsPerf::perfEnergy
-pimParamsPerf::getPerfEnergyForBytesTransfer(PimCmdEnum cmdType, uint64_t numBytes) const
+pimNS::perfEnergy
+pimPerfEnergyBase::getPerfEnergyForBytesTransfer(PimCmdEnum cmdType, uint64_t numBytes) const
 {
 
   double mjEnergy = 0.0;
@@ -63,13 +63,13 @@ pimParamsPerf::getPerfEnergyForBytesTransfer(PimCmdEnum cmdType, uint64_t numByt
       break;
     }
   }
-  return  perfEnergy(msRuntime, mjEnergy);
+  return  pimNS::perfEnergy(msRuntime, mjEnergy);
 }
 
 //! @brief  Get ms runtime for bit-serial PIM devices
 //!         BitSIMD and SIMDRAM need different fields
-pimParamsPerf::perfEnergy
-pimParamsPerf::getPerfEnergyBitSerial(PimDeviceEnum deviceType, PimCmdEnum cmdType, PimDataType dataType, unsigned bitsPerElement, unsigned numPass, const pimObjInfo& obj) const
+pimNS::perfEnergy
+pimPerfEnergyBase::getPerfEnergyBitSerial(PimDeviceEnum deviceType, PimCmdEnum cmdType, PimDataType dataType, unsigned bitsPerElement, unsigned numPass, const pimObjInfo& obj) const
 {
   bool ok = false;
   double msRuntime = 0.0;
@@ -125,12 +125,12 @@ pimParamsPerf::getPerfEnergyBitSerial(PimDeviceEnum deviceType, PimCmdEnum cmdTy
   msRuntime *= numPass;
   mjEnergy *= numPass;
 
-  return perfEnergy(msRuntime, mjEnergy);
+  return pimNS::perfEnergy(msRuntime, mjEnergy);
 }
 
 //! @brief  Get ms runtime for func1
-pimParamsPerf::perfEnergy
-pimParamsPerf::getPerfEnergyForFunc1(PimCmdEnum cmdType, const pimObjInfo& obj) const
+pimNS::perfEnergy
+pimPerfEnergyBase::getPerfEnergyForFunc1(PimCmdEnum cmdType, const pimObjInfo& obj) const
 {
   PimDeviceEnum simTarget = pimSim::get()->getSimTarget();
   double msRuntime = 0.0;
@@ -146,7 +146,7 @@ pimParamsPerf::getPerfEnergyForFunc1(PimCmdEnum cmdType, const pimObjInfo& obj) 
   case PIM_DEVICE_BITSIMD_H:
   case PIM_DEVICE_SIMDRAM:
   {
-    pimParamsPerf::perfEnergy perfEnergyBS = getPerfEnergyBitSerial(simTarget, cmdType, dataType, bitsPerElement, numPass, obj);
+    pimNS::perfEnergy perfEnergyBS = getPerfEnergyBitSerial(simTarget, cmdType, dataType, bitsPerElement, numPass, obj);
     msRuntime += perfEnergyBS.m_msRuntime;
     mjEnergy += perfEnergyBS.m_mjEnergy;
     break;
@@ -263,12 +263,12 @@ pimParamsPerf::getPerfEnergyForFunc1(PimCmdEnum cmdType, const pimObjInfo& obj) 
   }
   break;
   }
-  return perfEnergy(msRuntime, mjEnergy);
+  return pimNS::perfEnergy(msRuntime, mjEnergy);
 }
 
 //! @brief  Get ms runtime for func2
-pimParamsPerf::perfEnergy
-pimParamsPerf::getPerfEnergyForFunc2(PimCmdEnum cmdType, const pimObjInfo& obj) const
+pimNS::perfEnergy
+pimPerfEnergyBase::getPerfEnergyForFunc2(PimCmdEnum cmdType, const pimObjInfo& obj) const
 {
   PimDeviceEnum simTarget = pimSim::get()->getSimTarget();
   double msRuntime = 0.0;
@@ -284,7 +284,7 @@ pimParamsPerf::getPerfEnergyForFunc2(PimCmdEnum cmdType, const pimObjInfo& obj) 
   case PIM_DEVICE_BITSIMD_H:
   case PIM_DEVICE_SIMDRAM:
   {
-    pimParamsPerf::perfEnergy perfEnergyBS = getPerfEnergyBitSerial(simTarget, cmdType, dataType, bitsPerElement, numPass, obj);
+    pimNS::perfEnergy perfEnergyBS = getPerfEnergyBitSerial(simTarget, cmdType, dataType, bitsPerElement, numPass, obj);
     msRuntime += perfEnergyBS.m_msRuntime;
     mjEnergy += perfEnergyBS.m_mjEnergy;
     break;
@@ -425,12 +425,12 @@ pimParamsPerf::getPerfEnergyForFunc2(PimCmdEnum cmdType, const pimObjInfo& obj) 
     mjEnergy = 999999999.9;
   }
 
-  return perfEnergy(msRuntime, mjEnergy);
+  return pimNS::perfEnergy(msRuntime, mjEnergy);
 }
 
 //! @brief  Get ms runtime for reduction sum
-pimParamsPerf::perfEnergy
-pimParamsPerf::getPerfEnergyForRedSum(PimCmdEnum cmdType, const pimObjInfo& obj, unsigned numPass) const
+pimNS::perfEnergy
+pimPerfEnergyBase::getPerfEnergyForRedSum(PimCmdEnum cmdType, const pimObjInfo& obj, unsigned numPass) const
 {
   PimDeviceEnum simTarget = pimSim::get()->getSimTarget();
   double msRuntime = 0.0;
@@ -512,12 +512,12 @@ pimParamsPerf::getPerfEnergyForRedSum(PimCmdEnum cmdType, const pimObjInfo& obj,
     mjEnergy = 999999999.9; // todo
   }
 
-  return perfEnergy(msRuntime, mjEnergy);
+  return pimNS::perfEnergy(msRuntime, mjEnergy);
 }
 
 //! @brief  Get ms runtime for broadcast
-pimParamsPerf::perfEnergy
-pimParamsPerf::getPerfEnergyForBroadcast(PimCmdEnum cmdType, const pimObjInfo& obj) const
+pimNS::perfEnergy
+pimPerfEnergyBase::getPerfEnergyForBroadcast(PimCmdEnum cmdType, const pimObjInfo& obj) const
 {
   PimDeviceEnum simTarget = pimSim::get()->getSimTarget();
   double msRuntime = 0.0;
@@ -583,12 +583,12 @@ pimParamsPerf::getPerfEnergyForBroadcast(PimCmdEnum cmdType, const pimObjInfo& o
     mjEnergy = 999999999.9;
   }
 
-  return perfEnergy(msRuntime, mjEnergy);
+  return pimNS::perfEnergy(msRuntime, mjEnergy);
 }
 
 //! @brief  Get ms runtime for rotate
-pimParamsPerf::perfEnergy
-pimParamsPerf::getPerfEnergyForRotate(PimCmdEnum cmdType, const pimObjInfo& obj) const
+pimNS::perfEnergy
+pimPerfEnergyBase::getPerfEnergyForRotate(PimCmdEnum cmdType, const pimObjInfo& obj) const
 {
   PimDeviceEnum simTarget = pimSim::get()->getSimTarget();
   double msRuntime = 0.0;
@@ -597,7 +597,7 @@ pimParamsPerf::getPerfEnergyForRotate(PimCmdEnum cmdType, const pimObjInfo& obj)
   unsigned bitsPerElement = obj.getBitsPerElement();
   unsigned numRegions = obj.getRegions().size();
   // boundary handling
-  pimParamsPerf::perfEnergy perfEnergyBT = getPerfEnergyForBytesTransfer(cmdType, numRegions * bitsPerElement / 8);
+  pimNS::perfEnergy perfEnergyBT = getPerfEnergyForBytesTransfer(cmdType, numRegions * bitsPerElement / 8);
   switch (simTarget) {
   case PIM_DEVICE_BITSIMD_V:
   case PIM_DEVICE_BITSIMD_V_AP:
@@ -630,6 +630,6 @@ pimParamsPerf::getPerfEnergyForRotate(PimCmdEnum cmdType, const pimObjInfo& obj)
     mjEnergy = 999999999.9; // todo
   }
 
-  return perfEnergy(msRuntime, mjEnergy);
+  return pimNS::perfEnergy(msRuntime, mjEnergy);
 }
 

--- a/libpimeval/src/pimPerfEnergyModels.h
+++ b/libpimeval/src/pimPerfEnergyModels.h
@@ -25,6 +25,14 @@ namespace pimNS {
   };
 }
 
+//! @class  pimPerfEnergyFactory
+//! @brief  PIM performance energy model factory
+class pimPerfEnergyBase;
+class pimPerfEnergyFactory
+{
+public:
+  static pimPerfEnergyBase* getPerfEnergyModel(PimDeviceEnum simTarget, pimParamsDram* paramsDram);
+};
 
 //! @class  pimPerfEnergyBase
 //! @brief  PIM performance energy model base class
@@ -32,18 +40,16 @@ class pimPerfEnergyBase
 {
 public:
   pimPerfEnergyBase(pimParamsDram* paramsDram);
-  ~pimPerfEnergyBase() {}
+  virtual ~pimPerfEnergyBase() {}
 
-  pimNS::perfEnergy getPerfEnergyForBytesTransfer(PimCmdEnum cmdType, uint64_t numBytes) const;
-  pimNS::perfEnergy getPerfEnergyForFunc1(PimCmdEnum cmdType, const pimObjInfo& obj) const;
-  pimNS::perfEnergy getPerfEnergyForFunc2(PimCmdEnum cmdType, const pimObjInfo& obj) const;
-  pimNS::perfEnergy getPerfEnergyForRedSum(PimCmdEnum cmdType, const pimObjInfo& obj, unsigned numPass) const;
-  pimNS::perfEnergy getPerfEnergyForBroadcast(PimCmdEnum cmdType, const pimObjInfo& obj) const;
-  pimNS::perfEnergy getPerfEnergyForRotate(PimCmdEnum cmdType, const pimObjInfo& obj) const;
+  virtual pimNS::perfEnergy getPerfEnergyForBytesTransfer(PimCmdEnum cmdType, uint64_t numBytes) const;
+  virtual pimNS::perfEnergy getPerfEnergyForFunc1(PimCmdEnum cmdType, const pimObjInfo& obj) const;
+  virtual pimNS::perfEnergy getPerfEnergyForFunc2(PimCmdEnum cmdType, const pimObjInfo& obj) const;
+  virtual pimNS::perfEnergy getPerfEnergyForRedSum(PimCmdEnum cmdType, const pimObjInfo& obj, unsigned numPass) const;
+  virtual pimNS::perfEnergy getPerfEnergyForBroadcast(PimCmdEnum cmdType, const pimObjInfo& obj) const;
+  virtual pimNS::perfEnergy getPerfEnergyForRotate(PimCmdEnum cmdType, const pimObjInfo& obj) const;
 
-private:
-  pimNS::perfEnergy getPerfEnergyBitSerial(PimDeviceEnum deviceType, PimCmdEnum cmdType, PimDataType dataType, unsigned bitsPerElement, unsigned numPass, const pimObjInfo& obj) const;
-
+protected:
   const pimParamsDram* m_paramsDram;
   const double m_nano_to_milli = 1000000.0;
   const double m_pico_to_milli = 1000000000.0;
@@ -53,11 +59,6 @@ private:
   double m_tGDL; // Fetch data from local row buffer to global row buffer
   int m_GDLWidth; // Number of bits that can be fetched from local to global row buffer.
   int m_numChipsPerRank; // Number of chips per rank
-  double m_fulcrumAluLatency = 0.00000609; // 6.09ns
-
-  unsigned m_flucrumAluBitWidth = 32;
-  double m_blimpCoreLatency = 0.000005; // ms; 200 MHz. Reference: BLIMP paper
-  unsigned m_blimpCoreBitWidth = 64;
 
   double m_eAP; // Row read(ACT) energy in mJ microjoule
   double m_eL; // Logic energy in mJ microjoule
@@ -66,16 +67,73 @@ private:
   double m_pBCore; // background power for each core in W
   double m_pBChip; // background power for each core in W
   double m_eGDL = 0.0000102; // CAS energy in mJ
+};
+
+//! @class  pimPerfEnergyBitSerial
+//! @brief  PIM performance energy model for bit-serial PIM family
+class pimPerfEnergyBitSerial : public pimPerfEnergyBase
+{
+public:
+  pimPerfEnergyBitSerial(pimParamsDram* paramsDram)
+    : pimPerfEnergyBase(paramsDram) {}
+  virtual ~pimPerfEnergyBitSerial() {}
+
+  virtual pimNS::perfEnergy getPerfEnergyForFunc1(PimCmdEnum cmdType, const pimObjInfo& obj) const override;
+  virtual pimNS::perfEnergy getPerfEnergyForFunc2(PimCmdEnum cmdType, const pimObjInfo& obj) const override;
+  virtual pimNS::perfEnergy getPerfEnergyForRedSum(PimCmdEnum cmdType, const pimObjInfo& obj, unsigned numPass) const override;
+  virtual pimNS::perfEnergy getPerfEnergyForBroadcast(PimCmdEnum cmdType, const pimObjInfo& obj) const override;
+  virtual pimNS::perfEnergy getPerfEnergyForRotate(PimCmdEnum cmdType, const pimObjInfo& obj) const override;
+
+protected:
+  pimNS::perfEnergy getPerfEnergyBitSerial(PimDeviceEnum deviceType, PimCmdEnum cmdType, PimDataType dataType, unsigned bitsPerElement, unsigned numPass, const pimObjInfo& obj) const;
 
   // Popcount logc Params from DRAM-CAM paper
   double m_pclNsDelay = 0.76; // 64-bit popcount logic ns delay, using LUT no pipeline design
   double m_pclUwPower = 0.03; // 64-bit popcount logic uW power, using LUT no pipeline design
+};
 
+//! @class  pimPerfEnergyBitFulcrum
+//! @brief  PIM performance energy model for Fulcrum family
+class pimPerfEnergyFulcrum : public pimPerfEnergyBase
+{
+public:
+  pimPerfEnergyFulcrum(pimParamsDram* paramsDram)
+    : pimPerfEnergyBase(paramsDram) {}
+  virtual ~pimPerfEnergyFulcrum() {}
+
+  virtual pimNS::perfEnergy getPerfEnergyForFunc1(PimCmdEnum cmdType, const pimObjInfo& obj) const override;
+  virtual pimNS::perfEnergy getPerfEnergyForFunc2(PimCmdEnum cmdType, const pimObjInfo& obj) const override;
+  virtual pimNS::perfEnergy getPerfEnergyForRedSum(PimCmdEnum cmdType, const pimObjInfo& obj, unsigned numPass) const override;
+  virtual pimNS::perfEnergy getPerfEnergyForBroadcast(PimCmdEnum cmdType, const pimObjInfo& obj) const override;
+  virtual pimNS::perfEnergy getPerfEnergyForRotate(PimCmdEnum cmdType, const pimObjInfo& obj) const override;
+
+protected:
+  double m_fulcrumAluLatency = 0.00000609; // 6.09ns
+  unsigned m_flucrumAluBitWidth = 32;
   // Following values are taken from fulcrum paper.
   double m_fulcrumALUArithmeticEnergy = 0.0000000004992329586; // mJ
   double m_fulcrumALULogicalEnergy = 0.0000000001467846411; // mJ
   double m_fulcrumShiftEnergy = 0.0000000075; // mJ
+};
 
+//! @class  pimPerfEnergyBankLevel
+//! @brief  PIM performance energy model for bank-level PIM family
+class pimPerfEnergyBankLevel : public pimPerfEnergyBase
+{
+public:
+  pimPerfEnergyBankLevel(pimParamsDram* paramsDram)
+    : pimPerfEnergyBase(paramsDram) {}
+  virtual ~pimPerfEnergyBankLevel() {}
+
+  virtual pimNS::perfEnergy getPerfEnergyForFunc1(PimCmdEnum cmdType, const pimObjInfo& obj) const override;
+  virtual pimNS::perfEnergy getPerfEnergyForFunc2(PimCmdEnum cmdType, const pimObjInfo& obj) const override;
+  virtual pimNS::perfEnergy getPerfEnergyForRedSum(PimCmdEnum cmdType, const pimObjInfo& obj, unsigned numPass) const override;
+  virtual pimNS::perfEnergy getPerfEnergyForBroadcast(PimCmdEnum cmdType, const pimObjInfo& obj) const override;
+  virtual pimNS::perfEnergy getPerfEnergyForRotate(PimCmdEnum cmdType, const pimObjInfo& obj) const override;
+
+protected:
+  double m_blimpCoreLatency = 0.000005; // ms; 200 MHz. Reference: BLIMP paper
+  unsigned m_blimpCoreBitWidth = 64;
   // Following values are taken from fulcrum paper as BLIMP paper does not model energy
   double m_blimpArithmeticEnergy = 0.0000000004992329586; // mJ
   double m_blimpLogicalEnergy = 0.0000000001467846411; // mJ

--- a/libpimeval/src/pimPerfEnergyModels.h
+++ b/libpimeval/src/pimPerfEnergyModels.h
@@ -1,5 +1,5 @@
-// File: pimParamsPerf.h
-// PIMeval Simulator - Performance parameters
+// File: pimPerfEnergyModels.h
+// PIMeval Simulator - Performance Energy Models
 // Copyright (c) 2024 University of Virginia
 // This file is licensed under the MIT License.
 // See the LICENSE file in the root of this repository for more details.
@@ -13,14 +13,7 @@
 #include "pimResMgr.h"
 
 
-//! @class  pimParamsPerf
-//! @brief  PIM performance parameters base class
-class pimParamsPerf
-{
-public:
-  pimParamsPerf(pimParamsDram* paramsDram);
-  ~pimParamsPerf() {}
-
+namespace pimNS {
   class perfEnergy
   {
     public:
@@ -30,16 +23,26 @@ public:
       double m_msRuntime;
       double m_mjEnergy;
   };
+}
 
-  perfEnergy getPerfEnergyForBytesTransfer(PimCmdEnum cmdType, uint64_t numBytes) const;
-  perfEnergy getPerfEnergyForFunc1(PimCmdEnum cmdType, const pimObjInfo& obj) const;
-  perfEnergy getPerfEnergyForFunc2(PimCmdEnum cmdType, const pimObjInfo& obj) const;
-  perfEnergy getPerfEnergyForRedSum(PimCmdEnum cmdType, const pimObjInfo& obj, unsigned numPass) const;
-  perfEnergy getPerfEnergyForBroadcast(PimCmdEnum cmdType, const pimObjInfo& obj) const;
-  perfEnergy getPerfEnergyForRotate(PimCmdEnum cmdType, const pimObjInfo& obj) const;
+
+//! @class  pimPerfEnergyBase
+//! @brief  PIM performance energy model base class
+class pimPerfEnergyBase
+{
+public:
+  pimPerfEnergyBase(pimParamsDram* paramsDram);
+  ~pimPerfEnergyBase() {}
+
+  pimNS::perfEnergy getPerfEnergyForBytesTransfer(PimCmdEnum cmdType, uint64_t numBytes) const;
+  pimNS::perfEnergy getPerfEnergyForFunc1(PimCmdEnum cmdType, const pimObjInfo& obj) const;
+  pimNS::perfEnergy getPerfEnergyForFunc2(PimCmdEnum cmdType, const pimObjInfo& obj) const;
+  pimNS::perfEnergy getPerfEnergyForRedSum(PimCmdEnum cmdType, const pimObjInfo& obj, unsigned numPass) const;
+  pimNS::perfEnergy getPerfEnergyForBroadcast(PimCmdEnum cmdType, const pimObjInfo& obj) const;
+  pimNS::perfEnergy getPerfEnergyForRotate(PimCmdEnum cmdType, const pimObjInfo& obj) const;
 
 private:
-  perfEnergy getPerfEnergyBitSerial(PimDeviceEnum deviceType, PimCmdEnum cmdType, PimDataType dataType, unsigned bitsPerElement, unsigned numPass, const pimObjInfo& obj) const;
+  pimNS::perfEnergy getPerfEnergyBitSerial(PimDeviceEnum deviceType, PimCmdEnum cmdType, PimDataType dataType, unsigned bitsPerElement, unsigned numPass, const pimObjInfo& obj) const;
 
   const pimParamsDram* m_paramsDram;
   const double m_nano_to_milli = 1000000.0;

--- a/libpimeval/src/pimSim.cpp
+++ b/libpimeval/src/pimSim.cpp
@@ -77,13 +77,13 @@ pimSim::init(const std::string& simConfigFileConetnt)
         m_paramsDram = new pimParamsDram();
       }
 
-      m_paramsPerf = new pimParamsPerf(m_paramsDram);
-      m_statsMgr = new pimStatsMgr(m_paramsDram, m_paramsPerf);
+      m_perfEnergyModel = new pimPerfEnergyBase(m_paramsDram);
+      m_statsMgr = new pimStatsMgr(m_paramsDram, m_perfEnergyModel);
       m_initCalled = true;
     } else {
       m_paramsDram = new pimParamsDram();
-      m_paramsPerf = new pimParamsPerf(m_paramsDram);
-      m_statsMgr = new pimStatsMgr(m_paramsDram, m_paramsPerf);
+      m_perfEnergyModel = new pimPerfEnergyBase(m_paramsDram);
+      m_statsMgr = new pimStatsMgr(m_paramsDram, m_perfEnergyModel);
       m_initCalled = true;
     }
   }
@@ -100,8 +100,8 @@ pimSim::uninit()
   m_statsMgr = nullptr;
   delete m_paramsDram;
   m_paramsDram = nullptr;
-  delete m_paramsPerf;
-  m_paramsPerf = nullptr;
+  delete m_perfEnergyModel;
+  m_perfEnergyModel = nullptr;
   m_initCalled = false;
 }
 

--- a/libpimeval/src/pimSim.cpp
+++ b/libpimeval/src/pimSim.cpp
@@ -7,7 +7,6 @@
 #include "pimSim.h"
 #include "pimCmd.h"
 #include "pimParamsDram.h"
-#include "pimPerfEnergyModels.h"
 #include "pimStats.h"
 #include "pimUtils.h"
 #include <cstdio>
@@ -77,13 +76,11 @@ pimSim::init(const std::string& simConfigFileConetnt)
         m_paramsDram = new pimParamsDram();
       }
 
-      m_perfEnergyModel = new pimPerfEnergyBase(m_paramsDram);
-      m_statsMgr = new pimStatsMgr(m_paramsDram, m_perfEnergyModel);
+      m_statsMgr = new pimStatsMgr();
       m_initCalled = true;
     } else {
       m_paramsDram = new pimParamsDram();
-      m_perfEnergyModel = new pimPerfEnergyBase(m_paramsDram);
-      m_statsMgr = new pimStatsMgr(m_paramsDram, m_perfEnergyModel);
+      m_statsMgr = new pimStatsMgr();
       m_initCalled = true;
     }
   }
@@ -100,8 +97,6 @@ pimSim::uninit()
   m_statsMgr = nullptr;
   delete m_paramsDram;
   m_paramsDram = nullptr;
-  delete m_perfEnergyModel;
-  m_perfEnergyModel = nullptr;
   m_initCalled = false;
 }
 
@@ -358,6 +353,16 @@ pimSim::getNumCols() const
     return m_device->getNumCols();
   }
   return 0;
+}
+
+//! @brief  Get number of columns per PIM core
+pimPerfEnergyBase*
+pimSim::getPerfEnergyModel()
+{
+  if (m_device && m_device->isValid()) {
+    return m_device->getPerfEnergyModel();
+  }
+  return nullptr;
 }
 
 //! @brief  Show PIM command stats

--- a/libpimeval/src/pimSim.h
+++ b/libpimeval/src/pimSim.h
@@ -46,7 +46,7 @@ public:
   void resetStats() const;
   pimStatsMgr* getStatsMgr() { return m_statsMgr; }
   pimParamsDram* getParamsDram() { return m_paramsDram; }
-  pimParamsPerf* getParamsPerf() { return m_paramsPerf; }
+  pimPerfEnergyBase* getPerfEnergyModel() { return m_perfEnergyModel; }
 
   void initThreadPool(unsigned maxNumThreads);
   pimUtils::threadPool* getThreadPool() { return m_threadPool; }
@@ -142,7 +142,7 @@ private:
   // support one device for now
   pimDevice* m_device = nullptr;
   pimParamsDram* m_paramsDram = nullptr;
-  pimParamsPerf* m_paramsPerf = nullptr;
+  pimPerfEnergyBase* m_perfEnergyModel = nullptr;
   pimStatsMgr* m_statsMgr = nullptr;
   pimUtils::threadPool* m_threadPool = nullptr;
   unsigned m_numThreads = 0;

--- a/libpimeval/src/pimSim.h
+++ b/libpimeval/src/pimSim.h
@@ -46,7 +46,7 @@ public:
   void resetStats() const;
   pimStatsMgr* getStatsMgr() { return m_statsMgr; }
   pimParamsDram* getParamsDram() { return m_paramsDram; }
-  pimPerfEnergyBase* getPerfEnergyModel() { return m_perfEnergyModel; }
+  pimPerfEnergyBase* getPerfEnergyModel();
 
   void initThreadPool(unsigned maxNumThreads);
   pimUtils::threadPool* getThreadPool() { return m_threadPool; }
@@ -142,7 +142,6 @@ private:
   // support one device for now
   pimDevice* m_device = nullptr;
   pimParamsDram* m_paramsDram = nullptr;
-  pimPerfEnergyBase* m_perfEnergyModel = nullptr;
   pimStatsMgr* m_statsMgr = nullptr;
   pimUtils::threadPool* m_threadPool = nullptr;
   unsigned m_numThreads = 0;

--- a/libpimeval/src/pimStats.cpp
+++ b/libpimeval/src/pimStats.cpp
@@ -69,6 +69,7 @@ pimStatsMgr::showApiStats() const
 void
 pimStatsMgr::showDeviceParams() const
 {
+  pimParamsDram* paramsDram = pimSim::get()->getParamsDram();
   std::printf("PIM Params:\n");
   std::printf(" %30s : %s\n", "PIM Device Type Enum",
               pimUtils::pimDeviceEnumToStr(pimSim::get()->getDeviceType()).c_str());
@@ -83,12 +84,12 @@ pimStatsMgr::showDeviceParams() const
   std::printf(" %30s : %u\n", "Number of PIM Cores", pimSim::get()->getNumCores());
   std::printf(" %30s : %u\n", "Number of Rows per Core", pimSim::get()->getNumRows());
   std::printf(" %30s : %u\n", "Number of Cols per Core", pimSim::get()->getNumCols());
-  std::printf(" %30s : %f GB/s\n", "Typical Rank BW", m_paramsDram->getTypicalRankBW());
-  std::printf(" %30s : %f\n", "Row Read (ns)", m_paramsDram->getNsRowRead());
-  std::printf(" %30s : %f\n", "Row Write (ns)", m_paramsDram->getNsRowWrite());
-  std::printf(" %30s : %f\n", "tCCD (ns)", m_paramsDram->getNsTCCD_S());
+  std::printf(" %30s : %f GB/s\n", "Typical Rank BW", paramsDram->getTypicalRankBW());
+  std::printf(" %30s : %f\n", "Row Read (ns)", paramsDram->getNsRowRead());
+  std::printf(" %30s : %f\n", "Row Write (ns)", paramsDram->getNsRowWrite());
+  std::printf(" %30s : %f\n", "tCCD (ns)", paramsDram->getNsTCCD_S());
   #if defined(DEBUG)
-  std::printf(" %30s : %f\n", "AAP (ns)", m_paramsDram->getNsAAP());
+  std::printf(" %30s : %f\n", "AAP (ns)", paramsDram->getNsAAP());
   #endif
 }
 

--- a/libpimeval/src/pimStats.h
+++ b/libpimeval/src/pimStats.h
@@ -34,16 +34,16 @@ private:
 class pimStatsMgr
 {
 public:
-  pimStatsMgr(pimParamsDram* paramsDram, pimParamsPerf* paramsPerf)
+  pimStatsMgr(pimParamsDram* paramsDram, pimPerfEnergyBase* perfEnergyModel)
     : m_paramsDram(paramsDram),
-      m_paramsPerf(paramsPerf)
+      m_perfEnergyModel(perfEnergyModel)
   {}
   ~pimStatsMgr() {}
 
   void showStats() const;
   void resetStats();
   
-  void recordCmd(const std::string& cmdName, pimParamsPerf::perfEnergy mPerfEnergy) {
+  void recordCmd(const std::string& cmdName, pimNS::perfEnergy mPerfEnergy) {
     auto& item = m_cmdPerf[cmdName];
     item.first++;
     item.second.m_msRuntime += mPerfEnergy.m_msRuntime;
@@ -56,19 +56,19 @@ public:
     item.second += elapsed;
   }
 
-  void recordCopyMainToDevice(uint64_t numBits, pimParamsPerf::perfEnergy mPerfEnergy) { 
+  void recordCopyMainToDevice(uint64_t numBits, pimNS::perfEnergy mPerfEnergy) {
     m_bitsCopiedMainToDevice += numBits;
     m_elapsedTimeCopiedMainToDevice += mPerfEnergy.m_msRuntime;
     m_mJCopiedMainToDevice += mPerfEnergy.m_mjEnergy;
   }
 
-  void recordCopyDeviceToMain(uint64_t numBits, pimParamsPerf::perfEnergy mPerfEnergy) { 
+  void recordCopyDeviceToMain(uint64_t numBits, pimNS::perfEnergy mPerfEnergy) {
     m_bitsCopiedDeviceToMain += numBits; 
     m_elapsedTimeCopiedDeviceToMain += mPerfEnergy.m_msRuntime;
     m_mJCopiedDeviceToMain += mPerfEnergy.m_mjEnergy;
   }
   
-  void recordCopyDeviceToDevice(uint64_t numBits, pimParamsPerf::perfEnergy mPerfEnergy) { 
+  void recordCopyDeviceToDevice(uint64_t numBits, pimNS::perfEnergy mPerfEnergy) {
     m_bitsCopiedDeviceToDevice += numBits;
     m_elapsedTimeCopiedDeviceToDevice += mPerfEnergy.m_msRuntime;
     m_mJCopiedDeviceToDevice += mPerfEnergy.m_mjEnergy;
@@ -81,9 +81,9 @@ private:
   void showCmdStats() const;
 
   const pimParamsDram* m_paramsDram;
-  const pimParamsPerf* m_paramsPerf;
+  const pimPerfEnergyBase* m_perfEnergyModel;
 
-  std::map<std::string, std::pair<int, pimParamsPerf::perfEnergy>> m_cmdPerf;
+  std::map<std::string, std::pair<int, pimNS::perfEnergy>> m_cmdPerf;
   std::map<std::string, std::pair<int, double>> m_msElapsed;
 
   uint64_t m_bitsCopiedMainToDevice = 0;

--- a/libpimeval/src/pimStats.h
+++ b/libpimeval/src/pimStats.h
@@ -34,10 +34,7 @@ private:
 class pimStatsMgr
 {
 public:
-  pimStatsMgr(pimParamsDram* paramsDram, pimPerfEnergyBase* perfEnergyModel)
-    : m_paramsDram(paramsDram),
-      m_perfEnergyModel(perfEnergyModel)
-  {}
+  pimStatsMgr() {}
   ~pimStatsMgr() {}
 
   void showStats() const;
@@ -79,9 +76,6 @@ private:
   void showDeviceParams() const;
   void showCopyStats() const;
   void showCmdStats() const;
-
-  const pimParamsDram* m_paramsDram;
-  const pimPerfEnergyBase* m_perfEnergyModel;
 
   std::map<std::string, std::pair<int, pimNS::perfEnergy>> m_cmdPerf;
   std::map<std::string, std::pair<int, double>> m_msElapsed;


### PR DESCRIPTION
PR to dev-cleanup branch for early code review and incremental development.

Reorganize code of perf energy modes:
- Rename pimParamsPerf::perfEnergy to pimNS::perfEnergy
- Define pimPerfEnergyFactory
- Define pimPerfEnergyBase, pimPerfEnergyBitSerial, pimPerfEnergyFulcrum, pimPerfEnergyBankLevel
- Move perfEnergyModel from pimSim to pimDevice because of sim target dependency
- Update related code in pimSim, pimDevice, pimCmd, pimStats

Related to Discussion #143 

Warning: It's hard to diff pimPerfEnergyModels.h/cpp. There is no change on perf and energy formulas.