### PR TITLE
[main] Remove bitsPerElement parameter from default pimAlloc and pimAllocAssociated

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 LIBDIR := libpimeval
 BITSERIALDIR := bit-serial
 APPDIR := PIMbench
-TESTDIR := tests
+TESTDIR := misc-bench tests
 ALLDIRS := $(LIBDIR) $(BITSERIALDIR) $(APPDIR) $(TESTDIR)
 
 # Handle dependency between lib and apps to support make -j

--- a/PIMbench/aes/PIM/PIMAuxilary.cpp
+++ b/PIMbench/aes/PIM/PIMAuxilary.cpp
@@ -3,12 +3,12 @@
 #include <iostream>
 #include <cassert>
 
-PIMAuxilary::PIMAuxilary() : pimObjId(0), allocType(PIM_ALLOC_AUTO), numElements(0), bitsPerElements(0), dataType(PIM_UINT8) {
+PIMAuxilary::PIMAuxilary() : pimObjId(0), allocType(PIM_ALLOC_AUTO), numElements(0), dataType(PIM_UINT8) {
     // Constructor initialization
 }
 
 PIMAuxilary::PIMAuxilary(const PIMAuxilary* src) {
-    this->pimObjId = pimAllocAssociated(src->bitsPerElements, src->pimObjId, src->dataType);
+    this->pimObjId = pimAllocAssociated(src->pimObjId, src->dataType);
     if (this->pimObjId == -1) {
         std::cout << "Abort" << std::endl;
         abort();
@@ -17,12 +17,11 @@ PIMAuxilary::PIMAuxilary(const PIMAuxilary* src) {
     this->array.assign(src->array.begin(), src->array.end());  // Copy all elements from src to dest
     this->allocType = src->allocType;
     this->numElements = src->numElements;
-    this->bitsPerElements = src->bitsPerElements;
     this->dataType = src->dataType;
 }
 
-PIMAuxilary::PIMAuxilary(PimAllocEnum allocType, unsigned numElements, unsigned bitsPerElements, PimDataType dataType) {
-    this->pimObjId = pimAlloc(allocType, numElements, bitsPerElements, dataType);
+PIMAuxilary::PIMAuxilary(PimAllocEnum allocType, unsigned numElements, PimDataType dataType) {
+    this->pimObjId = pimAlloc(allocType, numElements, dataType);
     if (this->pimObjId == -1) {
         std::cout << "Abort" << std::endl;
         abort();
@@ -30,12 +29,11 @@ PIMAuxilary::PIMAuxilary(PimAllocEnum allocType, unsigned numElements, unsigned 
     this->array = *(new std::vector<uint8_t>(numElements));
     this->allocType = allocType;
     this->numElements = numElements;
-    this->bitsPerElements = bitsPerElements;
     this->dataType = dataType;
 }
 
-PIMAuxilary::PIMAuxilary(PimAllocEnum allocType, unsigned numElements, unsigned bitsPerElements, PimObjId ref, PimDataType dataType) {
-    this->pimObjId = pimAllocAssociated(bitsPerElements, ref, dataType);
+PIMAuxilary::PIMAuxilary(PimAllocEnum allocType, unsigned numElements, PimObjId ref, PimDataType dataType) {
+    this->pimObjId = pimAllocAssociated(ref, dataType);
     if (this->pimObjId == -1) {
         std::cout << "Abort" << std::endl;
         abort();
@@ -43,7 +41,6 @@ PIMAuxilary::PIMAuxilary(PimAllocEnum allocType, unsigned numElements, unsigned 
     this->array = std::vector<uint8_t>(numElements);
     this->allocType = allocType;
     this->numElements = numElements;
-    this->bitsPerElements = bitsPerElements;
     this->dataType = dataType;
 }
 

--- a/PIMbench/aes/PIM/PIMAuxilary.h
+++ b/PIMbench/aes/PIM/PIMAuxilary.h
@@ -12,13 +12,12 @@ public:
     PimObjId pimObjId;
     PimAllocEnum allocType;
     unsigned numElements;
-    unsigned bitsPerElements;
     PimDataType dataType;
 
 
     PIMAuxilary();
-    PIMAuxilary(PimAllocEnum allocType, unsigned numElements, unsigned bitsPerElements, PimDataType dataType);
-    PIMAuxilary(PimAllocEnum allocType, unsigned numElements, unsigned bitsPerElement, PimObjId ref, PimDataType dataType);
+    PIMAuxilary(PimAllocEnum allocType, unsigned numElements, PimDataType dataType);
+    PIMAuxilary(PimAllocEnum allocType, unsigned numElements, PimObjId ref, PimDataType dataType);
     PIMAuxilary(const PIMAuxilary* src); // Copy constructor
     ~PIMAuxilary();
 

--- a/PIMbench/aes/PIM/aes.cpp
+++ b/PIMbench/aes/PIM/aes.cpp
@@ -466,7 +466,6 @@ int testRjXtime(void){
     unsigned numSubarrayPerBank = 1024;
     unsigned numCores = numRanks * numBanks * numSubarrayPerBank / 2;
     unsigned numCols = 1024;
-    unsigned bitsPerElement = 8;
     unsigned totalElementCount = numCores * numCols;
 
 
@@ -477,7 +476,7 @@ int testRjXtime(void){
 
 
     
-    PIMAuxilary* xObj = new PIMAuxilary(PIM_ALLOC_AUTO, totalElementCount, bitsPerElement, PIM_UINT8);
+    PIMAuxilary* xObj = new PIMAuxilary(PIM_ALLOC_AUTO, totalElementCount, PIM_UINT8);
     PIMAuxilary* zObj = new PIMAuxilary(xObj);
 
 
@@ -524,7 +523,6 @@ int testAesSubBytes() {
 
     unsigned numCols = 1024; 
     unsigned totalCols = numCols * numCores;
-    unsigned bitsPerElement = 8;
     unsigned long numElements = totalCols;
     unsigned long numBytes = numElements * AES_BLOCK_SIZE;
    
@@ -534,7 +532,7 @@ int testAesSubBytes() {
     // Allocate memory for input buffers
     std::vector<PIMAuxilary*> *inputObjBuf = new std::vector<PIMAuxilary*>(AES_BLOCK_SIZE);
 
-    (*inputObjBuf)[0] = new PIMAuxilary(PIM_ALLOC_AUTO, numElements, bitsPerElement , PIM_UINT8);
+    (*inputObjBuf)[0] = new PIMAuxilary(PIM_ALLOC_AUTO, numElements, PIM_UINT8);
     for (unsigned j = 1; j < AES_BLOCK_SIZE; ++j) {
         (*inputObjBuf)[j] = new PIMAuxilary((*inputObjBuf)[0]);
     }
@@ -597,7 +595,6 @@ int testAesSubBytesInv() {
 
     unsigned numCols = 1024; 
     unsigned totalCols = numCols * numCores;
-    unsigned bitsPerElement = 8;
     unsigned long numElements = totalCols;
     unsigned long numBytes = numElements * AES_BLOCK_SIZE;
    
@@ -607,7 +604,7 @@ int testAesSubBytesInv() {
     // Allocate memory for input buffers
     std::vector<PIMAuxilary*> *inputObjBuf = new std::vector<PIMAuxilary*>(AES_BLOCK_SIZE);
 
-    (*inputObjBuf)[0] = new PIMAuxilary(PIM_ALLOC_AUTO, numElements, bitsPerElement , PIM_UINT8);
+    (*inputObjBuf)[0] = new PIMAuxilary(PIM_ALLOC_AUTO, numElements, PIM_UINT8);
     for (unsigned j = 1; j < AES_BLOCK_SIZE; ++j) {
         (*inputObjBuf)[j] = new PIMAuxilary((*inputObjBuf)[0]);
     }
@@ -677,7 +674,6 @@ int testAesAddRoundKey() {
 
     unsigned numCols = 1024; 
     unsigned totalCols = numCols * numCores;
-    unsigned bitsPerElement = 8;
     unsigned long numElements = totalCols;
     unsigned long numBytes = numElements * AES_BLOCK_SIZE;
    
@@ -687,7 +683,7 @@ int testAesAddRoundKey() {
     // Allocate memory for input buffers
     std::vector<PIMAuxilary*> *inputObjBuf = new std::vector<PIMAuxilary*>(AES_BLOCK_SIZE);
 
-    (*inputObjBuf)[0] = new PIMAuxilary(PIM_ALLOC_AUTO, numElements, bitsPerElement , PIM_UINT8);
+    (*inputObjBuf)[0] = new PIMAuxilary(PIM_ALLOC_AUTO, numElements, PIM_UINT8);
     for (unsigned j = 1; j < AES_BLOCK_SIZE; ++j) {
         (*inputObjBuf)[j] = new PIMAuxilary((*inputObjBuf)[0]);
     }
@@ -766,7 +762,6 @@ int testAesAddRoundKeyCpy(void) {
 
     unsigned numCols = 1024; 
     unsigned totalCols = numCols * numCores;
-    unsigned bitsPerElement = 8;
     unsigned long numElements = totalCols;
     unsigned long numBytes = numElements * AES_BLOCK_SIZE;
    
@@ -776,7 +771,7 @@ int testAesAddRoundKeyCpy(void) {
     // Allocate memory for input buffers
     std::vector<PIMAuxilary*> *inputObjBuf = new std::vector<PIMAuxilary*>(AES_BLOCK_SIZE);
 
-    (*inputObjBuf)[0] = new PIMAuxilary(PIM_ALLOC_AUTO, numElements, bitsPerElement , PIM_UINT8);
+    (*inputObjBuf)[0] = new PIMAuxilary(PIM_ALLOC_AUTO, numElements, PIM_UINT8);
     for (unsigned j = 1; j < AES_BLOCK_SIZE; ++j) {
         (*inputObjBuf)[j] = new PIMAuxilary((*inputObjBuf)[0]);
     }
@@ -885,7 +880,6 @@ int testAesShiftRows(void) {
 
     unsigned numCols = 1024; 
     unsigned totalCols = numCols * numCores;
-    unsigned bitsPerElement = 8;
     unsigned long numElements = totalCols;
     unsigned long numBytes = numElements * AES_BLOCK_SIZE;
    
@@ -896,7 +890,7 @@ int testAesShiftRows(void) {
     // Allocate memory for input buffers
     std::vector<PIMAuxilary*> *inputObjBuf = new std::vector<PIMAuxilary*>(AES_BLOCK_SIZE);
 
-    (*inputObjBuf)[0] = new PIMAuxilary(PIM_ALLOC_AUTO, numElements, bitsPerElement , PIM_UINT8);
+    (*inputObjBuf)[0] = new PIMAuxilary(PIM_ALLOC_AUTO, numElements, PIM_UINT8);
     for (unsigned j = 1; j < AES_BLOCK_SIZE; ++j) {
         (*inputObjBuf)[j] = new PIMAuxilary((*inputObjBuf)[0]);
 
@@ -963,7 +957,6 @@ int testAesShiftRowsInv(void) {
     unsigned numRows = 65536;
 
     unsigned numCols = 1024;
-    unsigned bitsPerElement = 8;
     unsigned long numBytes = numCols * AES_BLOCK_SIZE;
     unsigned totalElementCount = numCores * numCols / 2;
 
@@ -973,7 +966,7 @@ int testAesShiftRowsInv(void) {
     // Allocate memory for input buffers
     std::vector<PIMAuxilary*> *inputObjBuf = new std::vector<PIMAuxilary*>(AES_BLOCK_SIZE);
 
-    (*inputObjBuf)[0] = new PIMAuxilary(PIM_ALLOC_V1, totalElementCount, bitsPerElement, PIM_UINT8);
+    (*inputObjBuf)[0] = new PIMAuxilary(PIM_ALLOC_V1, totalElementCount, PIM_UINT8);
     for (unsigned j = 1; j < AES_BLOCK_SIZE; ++j) {
         (*inputObjBuf)[j] = new PIMAuxilary((*inputObjBuf)[0]);
 
@@ -1045,7 +1038,6 @@ int testAesMixColumns(void) {
     unsigned numRows = 65536;
 
     unsigned numCols = 8; 
-    unsigned bitsPerElement = 8;
     unsigned totalElementCount = numCores * numCols;
     unsigned long numBytes = totalElementCount * AES_BLOCK_SIZE;
 
@@ -1056,7 +1048,7 @@ int testAesMixColumns(void) {
     std::vector<PIMAuxilary*> *inputObjBuf = new std::vector<PIMAuxilary*>(AES_BLOCK_SIZE);
 
 
-    (*inputObjBuf)[0]= new PIMAuxilary(PIM_ALLOC_AUTO, totalElementCount, bitsPerElement, PIM_UINT8);
+    (*inputObjBuf)[0]= new PIMAuxilary(PIM_ALLOC_AUTO, totalElementCount, PIM_UINT8);
 
     for (unsigned j = 1; j < (AES_BLOCK_SIZE); ++j) {
         (*inputObjBuf)[j]= new PIMAuxilary((*inputObjBuf)[0]);
@@ -1123,7 +1115,6 @@ int testAesMixColumnsInv(void) {
     unsigned numRows = 65536;
 
     unsigned numCols = 8; 
-    unsigned bitsPerElement = 8;
     unsigned totalElementCount = numCores * numCols;
     unsigned long numBytes = totalElementCount * AES_BLOCK_SIZE;
 
@@ -1134,7 +1125,7 @@ int testAesMixColumnsInv(void) {
     std::vector<PIMAuxilary*> *inputObjBuf = new std::vector<PIMAuxilary*>(AES_BLOCK_SIZE);
 
 
-    (*inputObjBuf)[0]= new PIMAuxilary(PIM_ALLOC_AUTO, totalElementCount, bitsPerElement, PIM_UINT8);
+    (*inputObjBuf)[0]= new PIMAuxilary(PIM_ALLOC_AUTO, totalElementCount, PIM_UINT8);
 
     for (unsigned j = 1; j < (AES_BLOCK_SIZE); ++j) {
         (*inputObjBuf)[j]= new PIMAuxilary((*inputObjBuf)[0]);
@@ -1200,7 +1191,6 @@ int testAes256EncryptEcb(void) {
     unsigned numRows = 65536;
 
     unsigned numCols = 8; 
-    unsigned bitsPerElement = 8;
     unsigned totalElementCount = numCores * numCols;
     unsigned long numBytes = totalElementCount * AES_BLOCK_SIZE;
     
@@ -1211,7 +1201,7 @@ int testAes256EncryptEcb(void) {
     std::vector<PIMAuxilary*> *inputObjBuf = new std::vector<PIMAuxilary*>(AES_BLOCK_SIZE);
 
 
-    (*inputObjBuf)[0]= new PIMAuxilary(PIM_ALLOC_AUTO, totalElementCount, bitsPerElement, PIM_UINT8);
+    (*inputObjBuf)[0]= new PIMAuxilary(PIM_ALLOC_AUTO, totalElementCount, PIM_UINT8);
 
     for (unsigned j = 1; j < (AES_BLOCK_SIZE); ++j) {
         (*inputObjBuf)[j]= new PIMAuxilary((*inputObjBuf)[0]);
@@ -1286,7 +1276,6 @@ int testAes256DecryptEcb(void) {
     unsigned numRows = 65536;
 
     unsigned numCols = 8; 
-    unsigned bitsPerElement = 8;
     unsigned totalElementCount = numCores * numCols;
     unsigned long numBytes = totalElementCount * AES_BLOCK_SIZE;
 
@@ -1297,7 +1286,7 @@ int testAes256DecryptEcb(void) {
     std::vector<PIMAuxilary*> *inputObjBuf = new std::vector<PIMAuxilary*>(AES_BLOCK_SIZE);
 
 
-    (*inputObjBuf)[0]= new PIMAuxilary(PIM_ALLOC_AUTO, totalElementCount, bitsPerElement, PIM_UINT8);
+    (*inputObjBuf)[0]= new PIMAuxilary(PIM_ALLOC_AUTO, totalElementCount, PIM_UINT8);
 
     for (unsigned j = 1; j < (AES_BLOCK_SIZE); ++j) {
         (*inputObjBuf)[j]= new PIMAuxilary((*inputObjBuf)[0]);
@@ -1368,8 +1357,6 @@ int testEncryptdemo(void) {
     // unsigned long numBytes = 1310720; 
     unsigned long numBytes = 1UL * 1024 * 1024; // * 1024; // 1 GB
 
-    unsigned bitsPerElement = 8;
-
     // Each rank has 8 chips; Total Bank = 16; Each Bank contains 32 subarrays;
     unsigned numRanks = 2;
     unsigned numBankPerRank = 1; // 128; // 8 chips * 16 banks
@@ -1394,7 +1381,7 @@ int testEncryptdemo(void) {
     assert(status == PIM_OK);
 
     std::vector<PIMAuxilary*> *inputObjBuf = new std::vector<PIMAuxilary*>(AES_BLOCK_SIZE * numCalls);
-    (*inputObjBuf)[0]= new PIMAuxilary(PIM_ALLOC_AUTO, numElements, bitsPerElement, PIM_UINT8);
+    (*inputObjBuf)[0]= new PIMAuxilary(PIM_ALLOC_AUTO, numElements, PIM_UINT8);
    
     for (unsigned j = 1; j < (AES_BLOCK_SIZE * numCalls); ++j) {
         (*inputObjBuf)[j]= new PIMAuxilary((*inputObjBuf)[0]);
@@ -1470,8 +1457,6 @@ int testDecryptdemo(void) {
     // unsigned long numBytes = 1310720; 
     unsigned long numBytes = 1UL * 1024 * 1024 * 1024; // 1 GB
 
-    unsigned bitsPerElement = 8;
-
     // Each rank has 8 chips; Total Bank = 16; Each Bank contains 32 subarrays;
     unsigned numRanks = 2;
     unsigned numBankPerRank = 128; // 8 chips * 16 banks
@@ -1498,7 +1483,7 @@ int testDecryptdemo(void) {
 
 
     std::vector<PIMAuxilary*> *inputObjBuf = new std::vector<PIMAuxilary*>(AES_BLOCK_SIZE * numCalls);
-    (*inputObjBuf)[0]= new PIMAuxilary(PIM_ALLOC_AUTO, numElements, bitsPerElement, PIM_UINT8);
+    (*inputObjBuf)[0]= new PIMAuxilary(PIM_ALLOC_AUTO, numElements, PIM_UINT8);
    
     for (unsigned j = 1; j < (AES_BLOCK_SIZE * numCalls); ++j) {
         (*inputObjBuf)[j]= new PIMAuxilary((*inputObjBuf)[0]);
@@ -1657,9 +1642,6 @@ int testDemo(int argc, char **argv) {
     numbytes += padding;
     printf("INFO: Padding file with %d bytes for a new size of %lu\n", padding, numbytes);
 
-
-    unsigned bitsPerElement = 8;
-     
     // Each rank has 8 chips; Total Bank = 16; Each Bank contains 32 subarrays;
     unsigned numRanks = 2;
     unsigned numBankPerRank = 128; // 8 chips * 16 banks
@@ -1677,7 +1659,7 @@ int testDemo(int argc, char **argv) {
     assert(status == PIM_OK);
 
     std::vector<PIMAuxilary*> *inputObjBuf = new std::vector<PIMAuxilary*>(AES_BLOCK_SIZE * numCalls);
-    (*inputObjBuf)[0]= new PIMAuxilary(PIM_ALLOC_AUTO, numElements, bitsPerElement, PIM_UINT8);
+    (*inputObjBuf)[0]= new PIMAuxilary(PIM_ALLOC_AUTO, numElements, PIM_UINT8);
     for (unsigned j = 1; j < (AES_BLOCK_SIZE * numCalls); ++j) {
         (*inputObjBuf)[j]= new PIMAuxilary((*inputObjBuf)[0]);
     }

--- a/PIMbench/axpy/PIM/axpy.cpp
+++ b/PIMbench/axpy/PIM/axpy.cpp
@@ -79,11 +79,10 @@ struct Params getInputParams(int argc, char **argv)
 
 void axpy(uint64_t vectorLength, const std::vector<int> &X, const std::vector<int> &Y, int A, std::vector<int> &dst)
 {
-  unsigned bitsPerElement = sizeof(int) * 8;
-  PimObjId obj1 = pimAlloc(PIM_ALLOC_AUTO, vectorLength, bitsPerElement, PIM_INT32);
+  PimObjId obj1 = pimAlloc(PIM_ALLOC_AUTO, vectorLength, PIM_INT32);
   assert(obj1 != -1);
 
-  PimObjId obj2 = pimAllocAssociated(bitsPerElement, obj1, PIM_INT32);
+  PimObjId obj2 = pimAllocAssociated(obj1, PIM_INT32);
   assert(obj2 != -1);
 
   PimStatus status = pimCopyHostToDevice((void *)X.data(), obj1);

--- a/PIMbench/brightness/PIM/brightness.cpp
+++ b/PIMbench/brightness/PIM/brightness.cpp
@@ -83,14 +83,13 @@ struct Params getInputParams(int argc, char **argv)
 
 void brightness(uint64_t imgDataBytes, const std::vector<int16_t> &imgData, int coefficient, std::vector<int16_t> &resultData)
 {
-  unsigned bitsPerElement = sizeof(int16_t) * 8; 
-  PimObjId imgObj = pimAlloc(PIM_ALLOC_AUTO, imgDataBytes, bitsPerElement, PIM_INT16);
+  PimObjId imgObj = pimAlloc(PIM_ALLOC_AUTO, imgDataBytes, PIM_INT16);
   assert(imgObj != -1);
-  PimObjId additionObj = pimAllocAssociated(bitsPerElement, imgObj, PIM_INT16);
+  PimObjId additionObj = pimAllocAssociated(imgObj, PIM_INT16);
   assert(additionObj != -1);
-  PimObjId minObj = pimAllocAssociated(bitsPerElement, imgObj, PIM_INT16);
+  PimObjId minObj = pimAllocAssociated(imgObj, PIM_INT16);
   assert(minObj != -1);
-  PimObjId resultObj = pimAllocAssociated(bitsPerElement, imgObj, PIM_INT16);
+  PimObjId resultObj = pimAllocAssociated(imgObj, PIM_INT16);
   assert(resultObj != -1);
 
   PimStatus status = pimCopyHostToDevice((void *) imgData.data(), imgObj);

--- a/PIMbench/convolution/PIM/conv.cpp
+++ b/PIMbench/convolution/PIM/conv.cpp
@@ -147,10 +147,9 @@ void getDecomposedMatrix(int matrixRow, int matrixColumn, int filterRow, int fil
 
 void performConv(std::vector<std::vector<int>> &filterMatrix, std::vector<std::vector<int>> &inputMatrix, std::vector<int> &outputVector, int numRequiredPIMRows, int numRequiredPIMCol, bool moreDebugPrints)
 {
-  unsigned bitsPerElement = 32;
   std::vector<PimObjId> filterObjects;
   std::vector<int> temp;
-  PimObjId obj1 = pimAlloc(PIM_ALLOC_AUTO, numRequiredPIMCol, bitsPerElement, PIM_INT32);
+  PimObjId obj1 = pimAlloc(PIM_ALLOC_AUTO, numRequiredPIMCol, PIM_INT32);
   if (obj1 == -1)
   {
     std::cout << "Abort: pimAlloc failed for obj1" << std::endl;
@@ -159,7 +158,7 @@ void performConv(std::vector<std::vector<int>> &filterMatrix, std::vector<std::v
   filterObjects.push_back(obj1);
   for (int i = 1; i < numRequiredPIMRows; i++)
   {
-    PimObjId obj = pimAllocAssociated(bitsPerElement, filterObjects[0], PIM_INT32);
+    PimObjId obj = pimAllocAssociated(filterObjects[0], PIM_INT32);
     if (obj == -1)
     {
       std::cout << "Abort: pimAllocAssociated failed for obj (filterObjects) at iteration: " << i << std::endl;
@@ -185,7 +184,7 @@ void performConv(std::vector<std::vector<int>> &filterMatrix, std::vector<std::v
   std::vector<PimObjId> matrixObjects;
   for (int i = 0; i < numRequiredPIMRows; i++)
   {
-    PimObjId obj = pimAllocAssociated(bitsPerElement, filterObjects[0], PIM_INT32);
+    PimObjId obj = pimAllocAssociated(filterObjects[0], PIM_INT32);
     if (obj == -1)
     {
       std::cout << "Abort: pimAllocAssociated failed obj (matrixObjects) at iteration: " << i << std::endl;

--- a/PIMbench/filter-by-key/PIM/filter.cpp
+++ b/PIMbench/filter-by-key/PIM/filter.cpp
@@ -131,15 +131,12 @@ int main(int argc, char **argv){
     std::vector<int> bitMap(inVectorSize, 0);
     std::vector<int> bitMapHost(inVectorSize, 0);
 
-    //PIM parameters
-    unsigned bitsPerElement = 32;
-
-    PimObjId srcObj1 = pimAlloc(PIM_ALLOC_AUTO, inVector.size(), bitsPerElement, PIM_INT32);
+    PimObjId srcObj1 = pimAlloc(PIM_ALLOC_AUTO, inVector.size(), PIM_INT32);
     if (srcObj1 == -1){
         std::cout << "Abort" << std::endl;
         return 1;
     }
-    PimObjId srcObj2 = pimAllocAssociated(bitsPerElement, srcObj1, PIM_INT32);
+    PimObjId srcObj2 = pimAllocAssociated(srcObj1, PIM_INT32);
     if (srcObj2 == -1){
         std::cout << "Abort" << std::endl;
         return 1;

--- a/PIMbench/gemm/PIM/gemm.cpp
+++ b/PIMbench/gemm/PIM/gemm.cpp
@@ -86,21 +86,20 @@ struct Params getInputParams(int argc, char **argv)
 
 void gemv(uint64_t row, uint64_t col, std::vector<int> &srcVector, std::vector<std::vector<int>> &srcMatrix, std::vector<int> &dst)
 {
-  unsigned bitsPerElement = sizeof(int) * 8;
-  PimObjId srcObj1 = pimAlloc(PIM_ALLOC_AUTO, row, bitsPerElement, PIM_INT32);
+  PimObjId srcObj1 = pimAlloc(PIM_ALLOC_AUTO, row, PIM_INT32);
   if (srcObj1 == -1)
   {
     std::cout << "Abort" << std::endl;
     return;
   }
-  PimObjId srcObj2 = pimAllocAssociated(bitsPerElement, srcObj1, PIM_INT32);
+  PimObjId srcObj2 = pimAllocAssociated(srcObj1, PIM_INT32);
   if (srcObj2 == -1)
   {
     std::cout << "Abort" << std::endl;
     return;
   }
 
-  PimObjId dstObj = pimAllocAssociated(bitsPerElement, srcObj1, PIM_INT32);
+  PimObjId dstObj = pimAllocAssociated(srcObj1, PIM_INT32);
   if (dstObj == -1)
   {
     std::cout << "Abort" << std::endl;

--- a/PIMbench/gemv/PIM/gemv.cpp
+++ b/PIMbench/gemv/PIM/gemv.cpp
@@ -81,21 +81,20 @@ struct Params getInputParams(int argc, char **argv)
 
 void gemv(uint64_t row, uint64_t col, std::vector<int> &srcVector, std::vector<std::vector<int>> &srcMatrix, std::vector<int> &dst)
 {
-  unsigned bitsPerElement = sizeof(int) * 8;
-  PimObjId srcObj1 = pimAlloc(PIM_ALLOC_AUTO, row, bitsPerElement, PIM_INT32);
+  PimObjId srcObj1 = pimAlloc(PIM_ALLOC_AUTO, row, PIM_INT32);
   if (srcObj1 == -1)
   {
     std::cout << "Abort" << std::endl;
     return;
   }
-  PimObjId srcObj2 = pimAllocAssociated(bitsPerElement, srcObj1, PIM_INT32);
+  PimObjId srcObj2 = pimAllocAssociated(srcObj1, PIM_INT32);
   if (srcObj2 == -1)
   {
     std::cout << "Abort" << std::endl;
     return;
   }
 
-  PimObjId dstObj = pimAllocAssociated(bitsPerElement, srcObj1, PIM_INT32);
+  PimObjId dstObj = pimAllocAssociated(srcObj1, PIM_INT32);
   if (dstObj == -1)
   {
     std::cout << "Abort" << std::endl;

--- a/PIMbench/histogram/PIM/hist.cpp
+++ b/PIMbench/histogram/PIM/hist.cpp
@@ -78,14 +78,13 @@ struct Params getInputParams(int argc, char **argv)
 void histogram(uint64_t imgDataBytes, const std::vector<uint8_t> &redData, const std::vector<uint8_t> &greenData, const std::vector<uint8_t> &blueData, 
                std::vector<uint64_t> &redCount, std::vector<uint64_t> &greenCount, std::vector<uint64_t> &blueCount) 
 {
-  unsigned bitsPerElement = sizeof(uint8_t) * 8;
-  PimObjId redObj = pimAlloc(PIM_ALLOC_AUTO, imgDataBytes, bitsPerElement, PIM_UINT8);
+  PimObjId redObj = pimAlloc(PIM_ALLOC_AUTO, imgDataBytes, PIM_UINT8);
   assert(redObj != -1);
-  PimObjId greenObj = pimAllocAssociated(bitsPerElement, redObj, PIM_UINT8);
+  PimObjId greenObj = pimAllocAssociated(redObj, PIM_UINT8);
   assert(greenObj != -1);
-  PimObjId blueObj = pimAllocAssociated(bitsPerElement, redObj, PIM_UINT8);
+  PimObjId blueObj = pimAllocAssociated(redObj, PIM_UINT8);
   assert(blueObj != -1);
-  PimObjId tempObj = pimAllocAssociated(bitsPerElement, redObj, PIM_UINT8);
+  PimObjId tempObj = pimAllocAssociated(redObj, PIM_UINT8);
   assert(tempObj != -1);
 
   PimStatus status = pimCopyHostToDevice((void *) redData.data(), redObj);

--- a/PIMbench/image-downsampling/PIM/image-downsampling.cpp
+++ b/PIMbench/image-downsampling/PIM/image-downsampling.cpp
@@ -108,7 +108,6 @@ constexpr int bits_per_pixel = 24;
 constexpr int min_data_offset = 0x36;
 constexpr int color_channels_per_pixel = 3;
 constexpr int bmp_scanline_padding_multiple = 4; // BMP file format specifies that scanlines are padded to nearest 4 byte boundary
-constexpr int bits_per_element = 8;
 constexpr int shift_amount = 2;
 
 NewImgWrapper parseInputImageandSetupOutputImage(std::vector<uint8_t> img, bool print_size=false)
@@ -182,16 +181,16 @@ void pimAverageRows(vector<uint8_t>& upper_left, vector<uint8_t>& upper_right, v
   // Returns average of the four input vectors as a uint8_t array
   int sz = upper_left.size();
 
-  PimObjId ul = pimAlloc(PIM_ALLOC_AUTO, sz, bits_per_element, PIM_UINT8);
+  PimObjId ul = pimAlloc(PIM_ALLOC_AUTO, sz, PIM_UINT8);
   assert(-1 != ul);
 
-  PimObjId ur = pimAllocAssociated(bits_per_element, ul, PIM_UINT8);
+  PimObjId ur = pimAllocAssociated(ul, PIM_UINT8);
   assert(-1 != ur);
 
-  PimObjId ll = pimAllocAssociated(bits_per_element, ul, PIM_UINT8);
+  PimObjId ll = pimAllocAssociated(ul, PIM_UINT8);
   assert(-1 != ll);
 
-  PimObjId lr = pimAllocAssociated(bits_per_element, ul, PIM_UINT8);
+  PimObjId lr = pimAllocAssociated(ul, PIM_UINT8);
   assert(-1 != lr);
 
   PimStatus ul_status = pimCopyHostToDevice(upper_left.data(), ul);

--- a/PIMbench/kmeans/PIM/km.cpp
+++ b/PIMbench/kmeans/PIM/km.cpp
@@ -100,10 +100,9 @@ struct Params getInputParams(int argc, char **argv)
 void allocatePimObject(uint64_t numOfPoints, int dimension, std::vector<PimObjId> &pimObjectList, PimObjId refObj)
 {
   int idx = 0;
-  unsigned bitsPerElement = sizeof(int) * 8;
   if (refObj == -1)
   {
-    PimObjId obj1 = pimAlloc(PIM_ALLOC_AUTO, numOfPoints, bitsPerElement, PIM_INT32);
+    PimObjId obj1 = pimAlloc(PIM_ALLOC_AUTO, numOfPoints, PIM_INT32);
     if (obj1 == -1)
     {
       std::cout << "Abort" << std::endl;
@@ -116,7 +115,7 @@ void allocatePimObject(uint64_t numOfPoints, int dimension, std::vector<PimObjId
 
   for (; idx < dimension; ++idx)
   {
-    PimObjId obj = pimAllocAssociated(bitsPerElement, refObj, PIM_INT32);
+    PimObjId obj = pimAllocAssociated(refObj, PIM_INT32);
     if (obj == -1)
     {
       std::cout << "Abort" << std::endl;
@@ -165,7 +164,7 @@ void runKmeans(uint64_t numOfPoints, int dimension, int k, int iteration, const 
   allocatePimObject(numOfPoints, dimension, centroidObjectList, dataPointObjectList[0]);
   allocatePimObject(numOfPoints, dimension, resultObjectList, dataPointObjectList[0]);
   // this object stores the minimum distance
-  PimObjId tempObj = pimAllocAssociated(sizeof(int) * 8, resultObjectList[0], PIM_INT32);
+  PimObjId tempObj = pimAllocAssociated(resultObjectList[0], PIM_INT32);
   if (tempObj == -1)
   {
     std::cout << "Abort" << std::endl;

--- a/PIMbench/knn/PIM/knn.cpp
+++ b/PIMbench/knn/PIM/knn.cpp
@@ -227,10 +227,9 @@ bool knn_test(vector<vector<int>> ref,
 void allocatePimObject(uint64_t numOfPoints, int dimension, std::vector<PimObjId> &pimObjectList, PimObjId refObj)
 {
   int idx = 0;
-  unsigned bitsPerElement = sizeof(int) * 8;
   if (refObj == -1)
   {
-    PimObjId obj1 = pimAlloc(PIM_ALLOC_AUTO, numOfPoints, bitsPerElement, PIM_INT32);
+    PimObjId obj1 = pimAlloc(PIM_ALLOC_AUTO, numOfPoints, PIM_INT32);
     if (obj1 == -1)
     {
       std::cout << "Abort" << std::endl;
@@ -243,7 +242,7 @@ void allocatePimObject(uint64_t numOfPoints, int dimension, std::vector<PimObjId
 
   for (; idx < dimension; ++idx)
   {
-    PimObjId obj = pimAllocAssociated(bitsPerElement, refObj, PIM_INT32);
+    PimObjId obj = pimAllocAssociated(refObj, PIM_INT32);
     if (obj == -1)
     {
       std::cout << "Abort" << std::endl;

--- a/PIMbench/linear-regression/PIM/lr.cpp
+++ b/PIMbench/linear-regression/PIM/lr.cpp
@@ -80,9 +80,7 @@ struct Params getInputParams(int argc, char **argv)
 
 void linearRegression(uint64_t dataSize, const std::vector<int> &X, const std::vector<int> &Y, int64_t &SX, int64_t &SY, int64_t &SXX, int64_t &SXY)
 {
-  unsigned bitsPerElement = sizeof(int) * 8;
-
-  PimObjId srcObj1 = pimAlloc(PIM_ALLOC_AUTO, dataSize, bitsPerElement, PIM_INT32);
+  PimObjId srcObj1 = pimAlloc(PIM_ALLOC_AUTO, dataSize, PIM_INT32);
   if (srcObj1 == -1)
   {
     std::cout << "Abort" << std::endl;
@@ -103,7 +101,7 @@ void linearRegression(uint64_t dataSize, const std::vector<int> &X, const std::v
     return;
   }
 
-  PimObjId srcObj2 = pimAllocAssociated(bitsPerElement, srcObj1, PIM_INT32);
+  PimObjId srcObj2 = pimAllocAssociated(srcObj1, PIM_INT32);
   if (srcObj2 == -1)
   {
     std::cout << "Abort" << std::endl;

--- a/PIMbench/pooling/PIM/pool.cpp
+++ b/PIMbench/pooling/PIM/pool.cpp
@@ -140,8 +140,6 @@ void decomposeMatrix(int matrixRow, int matrixColumn, int kernelHeight, int kern
 */
 void maxPool(const std::vector<std::vector<int>> &inputMatrix, std::vector<int> &outputMatrix)
 {
-  unsigned bitsPerElement = 32;
-
   if (inputMatrix.empty())
   {
     std::cerr << "Abort: input matrix is empty" << std::endl;
@@ -151,7 +149,7 @@ void maxPool(const std::vector<std::vector<int>> &inputMatrix, std::vector<int> 
   int numCols = inputMatrix[0].size();
 
   std::vector<PimObjId> pimObjectList(numRows);
-  PimObjId obj1 = pimAlloc(PIM_ALLOC_AUTO, numCols, bitsPerElement, PIM_INT32);
+  PimObjId obj1 = pimAlloc(PIM_ALLOC_AUTO, numCols, PIM_INT32);
   if (obj1 == -1)
   {
     std::cerr << "Abort: pimAlloc failed for obj1" << std::endl;
@@ -160,7 +158,7 @@ void maxPool(const std::vector<std::vector<int>> &inputMatrix, std::vector<int> 
   pimObjectList[0] = obj1;
   for (int i = 1; i < numRows; i++)
   {
-    PimObjId obj = pimAllocAssociated(bitsPerElement, pimObjectList[0], PIM_INT32);
+    PimObjId obj = pimAllocAssociated(pimObjectList[0], PIM_INT32);
     if (obj == -1)
     {
       std::cerr << "Abort: pimAllocAssociated failed pimObjectList at iteration: " << i << std::endl;

--- a/PIMbench/radix-sort/PIM/radix-sort.cpp
+++ b/PIMbench/radix-sort/PIM/radix-sort.cpp
@@ -97,23 +97,22 @@ int main(int argc, char *argv[])
     std::vector<PimObjId> compare_obj(num_passes);
     std::vector<PimObjId> compare_results_obj(num_passes);
 
-    //What is the difference between bitsPerElement and PIM_INT32
     for(unsigned i = 0; i < num_passes; i++){
-        src_obj[i] = pimAlloc(PIM_ALLOC_AUTO, numElements, bitsPerElement, PIM_INT32);
+        src_obj[i] = pimAlloc(PIM_ALLOC_AUTO, numElements, PIM_INT32);
         if (src_obj[i] == -1) {
             std::cout << "Abort" << std::endl;
             return 1;
         }
     }
     for(unsigned i = 0; i < num_passes; i++){
-        compare_obj[i] = pimAllocAssociated(bitsPerElement, src_obj[i], PIM_INT32);
+        compare_obj[i] = pimAllocAssociated(src_obj[i], PIM_INT32);
         if (compare_obj[i] == -1) {
             std::cout << "Abort" << std::endl;
             return 1;
         }
     }
     for(unsigned i = 0; i < num_passes; i++){
-        compare_results_obj[i] = pimAllocAssociated(bitsPerElement, src_obj[i], PIM_INT32);
+        compare_results_obj[i] = pimAllocAssociated(src_obj[i], PIM_INT32);
         if (compare_results_obj[i] == -1) {
             std::cout << "Abort" << std::endl;
             return 1;

--- a/PIMbench/relu/PIM/relu.cpp
+++ b/PIMbench/relu/PIM/relu.cpp
@@ -118,7 +118,7 @@ void decomposeMatrix(int matrixRow, int matrixColumn, int kernelHeight, int kern
 /*
   This should work for bitSIMD or any PIM that requires vertical data layout.
 */
-void performRelu(const std::vector<std::vector<int>> &inputMatrix, std::vector<int> &outputMatrix, unsigned bitsPerElement)
+void performRelu(const std::vector<std::vector<int>> &inputMatrix, std::vector<int> &outputMatrix)
 {
 
   if (inputMatrix.empty())
@@ -132,7 +132,7 @@ void performRelu(const std::vector<std::vector<int>> &inputMatrix, std::vector<i
   uint64_t reluConst = 0;  
 
   std::vector<PimObjId> pimObjectList(numRows);
-  PimObjId obj1 = pimAlloc(PIM_ALLOC_AUTO, numCols, bitsPerElement, PIM_INT32);
+  PimObjId obj1 = pimAlloc(PIM_ALLOC_AUTO, numCols, PIM_INT32);
   if (obj1 == -1)
   {
     std::cout << "Abort: pimAlloc for PimObj obj1 failed" << std::endl;
@@ -141,7 +141,7 @@ void performRelu(const std::vector<std::vector<int>> &inputMatrix, std::vector<i
   pimObjectList[0] = obj1;
   for (int i = 1; i < numRows; i++)
   {
-    PimObjId obj = pimAllocAssociated(bitsPerElement, pimObjectList[0], PIM_INT32);
+    PimObjId obj = pimAllocAssociated(pimObjectList[0], PIM_INT32);
     if (obj == -1)
     {
       std::cout << "Abort: pimAllocAssociated for PimObj obj failed" << std::endl;
@@ -302,7 +302,7 @@ int main(int argc, char *argv[]) {
     }
   }
   
-  performRelu(mergedMat, outVector, bitsPerElement);
+  performRelu(mergedMat, outVector);
   if (params.moreDebugPrints) {
     // Debug print outVector
     std::cout << "outVector:" << std::endl;            

--- a/PIMbench/triangle-count/PIM/tc.cpp
+++ b/PIMbench/triangle-count/PIM/tc.cpp
@@ -147,11 +147,9 @@ vector<pair<int, int>> readEdgeList(const string& filename) {
 }
 
 int vectorAndPopCntRedSum(uint64_t numElements, std::vector<unsigned int> &src1, std::vector<unsigned int> &src2, std::vector<unsigned int> &dst, std::vector<unsigned int> &popCountSrc) {
-    unsigned bitsPerElement = sizeof(int) * 8;
-
     cout << "numElements: " << numElements << endl;
 
-    PimObjId srcObj1 = pimAlloc(PIM_ALLOC_AUTO, numElements, bitsPerElement, PIM_INT32);
+    PimObjId srcObj1 = pimAlloc(PIM_ALLOC_AUTO, numElements, PIM_INT32);
     if (srcObj1 == -1)
     {
         std::cout << "src1: pimAlloc" << std::endl;
@@ -159,7 +157,7 @@ int vectorAndPopCntRedSum(uint64_t numElements, std::vector<unsigned int> &src1,
     }
     if (DEBUG) cout << "src1 allocated successfully!" << endl;
 
-    PimObjId srcObj2 = pimAllocAssociated(bitsPerElement, srcObj1, PIM_INT32);
+    PimObjId srcObj2 = pimAllocAssociated(srcObj1, PIM_INT32);
     if (srcObj2 == -1)
     {
         std::cout << "src2: pimAllocAssociated" << std::endl;
@@ -167,7 +165,7 @@ int vectorAndPopCntRedSum(uint64_t numElements, std::vector<unsigned int> &src1,
     }
     if (DEBUG) cout << "src2 allocated successfully!" << endl;
 
-    PimObjId dstObj = pimAllocAssociated(bitsPerElement, srcObj1, PIM_INT32);
+    PimObjId dstObj = pimAllocAssociated(srcObj1, PIM_INT32);
     if (dstObj == -1)
     {
         std::cout << "dst: pimAllocAssociated" << std::endl;
@@ -175,7 +173,7 @@ int vectorAndPopCntRedSum(uint64_t numElements, std::vector<unsigned int> &src1,
     }
     if (DEBUG) cout << "dst allocated successfully!" << endl;
 
-    PimObjId popCountSrcObj = pimAllocAssociated(bitsPerElement, srcObj1, PIM_INT32);
+    PimObjId popCountSrcObj = pimAllocAssociated(srcObj1, PIM_INT32);
     if (popCountSrcObj == -1)
     {
         std::cout << "popCountSrc: pimAllocAssociated" << std::endl;

--- a/PIMbench/utilML.h
+++ b/PIMbench/utilML.h
@@ -102,10 +102,9 @@ void softmaxOnHost(const std::vector<T> &input, std::vector<double> &output)
 // The summed results are then copied from the PIM (device) to Host.
 void performConv(std::vector<std::vector<int>> &filterMatrix, std::vector<std::vector<int>> &inputMatrix, std::vector<int> &outputMatrix, int numRequiredPIMRows, int numRequiredPIMCol)
 {
-  unsigned bitsPerElement = 32;
   std::vector<PimObjId> filterObjects;
   std::vector<int> temp;
-  PimObjId obj1 = pimAlloc(PIM_ALLOC_AUTO, numRequiredPIMCol, bitsPerElement, PIM_INT32);
+  PimObjId obj1 = pimAlloc(PIM_ALLOC_AUTO, numRequiredPIMCol, PIM_INT32);
   if (obj1 == -1)
   {
     std::cout << "Function: " << __func__ << "Abort: pimAlloc failed for obj1" << std::endl;
@@ -114,7 +113,7 @@ void performConv(std::vector<std::vector<int>> &filterMatrix, std::vector<std::v
   filterObjects.push_back(obj1);
   for (int i = 1; i < numRequiredPIMRows; i++)
   {
-    PimObjId obj = pimAllocAssociated(bitsPerElement, filterObjects[0], PIM_INT32);
+    PimObjId obj = pimAllocAssociated(filterObjects[0], PIM_INT32);
     if (obj == -1)
     {
       std::cout << "Function: " << __func__ << "Abort: pimAllocAssociated failed for obj at i=" << i << std::endl;
@@ -140,7 +139,7 @@ void performConv(std::vector<std::vector<int>> &filterMatrix, std::vector<std::v
   std::vector<PimObjId> matrixObjects;
   for (int i = 0; i < numRequiredPIMRows; i++)
   {
-    PimObjId obj = pimAllocAssociated(bitsPerElement, filterObjects[0], PIM_INT32);
+    PimObjId obj = pimAllocAssociated(filterObjects[0], PIM_INT32);
     if (obj == -1)
     {
       std::cout << "Function: " << __func__ << "Abort: pimAllocAssociated failed for obj at i=" << i << std::endl;
@@ -287,8 +286,6 @@ void conv2(std::vector<std::vector<std::vector<int>>> &inputMatrix, std::vector<
 // The max results from pimObjectList[0] are then copied from the PIM (device) to Host.
 void maxPool(const std::vector<std::vector<int>> &inputMatrix, std::vector<int> &outputMatrix)
 {
-  unsigned bitsPerElement = 32;
-
   if (inputMatrix.empty())
   {
     return;
@@ -297,7 +294,7 @@ void maxPool(const std::vector<std::vector<int>> &inputMatrix, std::vector<int> 
   int numCols = inputMatrix[0].size();
 
   std::vector<PimObjId> pimObjectList(numRows);
-  PimObjId obj1 = pimAlloc(PIM_ALLOC_AUTO, numCols, bitsPerElement, PIM_INT32);
+  PimObjId obj1 = pimAlloc(PIM_ALLOC_AUTO, numCols, PIM_INT32);
   if (obj1 == -1)
   {
     std::cout << "Function: " << __func__ << "Abort: pimAlloc failed for obj1" << std::endl;
@@ -306,7 +303,7 @@ void maxPool(const std::vector<std::vector<int>> &inputMatrix, std::vector<int> 
   pimObjectList[0] = obj1;
   for (int i = 1; i < numRows; i++)
   {
-    PimObjId obj = pimAllocAssociated(bitsPerElement, pimObjectList[0], PIM_INT32);
+    PimObjId obj = pimAllocAssociated(pimObjectList[0], PIM_INT32);
     if (obj == -1)
     {
       std::cout << "Function: " << __func__ << "Abort: pimAllocAssociated failed for obj at i=" << i << std::endl;
@@ -416,15 +413,14 @@ void pool(std::vector<std::vector<std::vector<int>>> &inputMatrix, int kernelHei
 // The accumulated results are then copied from the PIM (device) to the host. 
 void gemv(uint64_t row, uint64_t col, std::vector<int> &srcVector, std::vector<std::vector<int>> &srcMatrix, std::vector<int> &dst)
 {
-  unsigned bitsPerElement = sizeof(int) * 8;
-  PimObjId srcObj = pimAlloc(PIM_ALLOC_AUTO, row, bitsPerElement, PIM_INT32);
+  PimObjId srcObj = pimAlloc(PIM_ALLOC_AUTO, row, PIM_INT32);
   if (srcObj == -1)
   {
     std::cout << "Function: " << __func__ << ", Abort: pimAlloc failed for srcObj" << std::endl;
     return;
   }
 
-  PimObjId dstObj = pimAllocAssociated(bitsPerElement, srcObj, PIM_INT32);
+  PimObjId dstObj = pimAllocAssociated(srcObj, PIM_INT32);
   if (dstObj == -1)
   {
     std::cout << "Function: " << __func__ << ", Abort: pimAllocAssociated failed for dstObj" << std::endl;
@@ -470,8 +466,6 @@ void gemv(uint64_t row, uint64_t col, std::vector<int> &srcVector, std::vector<s
 // The max results from pimObject are then copied from the PIM (device) to Host.
 void performRelu(std::vector<int> &inputVector)
 {
-  unsigned bitsPerElement = 32;
-
   if (inputVector.empty()) {
     std::cout << "Function: " << __func__ << ", Abort: Input matrix is empty" << std::endl;    
     return;
@@ -481,13 +475,13 @@ void performRelu(std::vector<int> &inputVector)
   // Initialize reluConst vector with zero for max(0, x) operation.
   std::vector<int> reluConst(numCols, 0);  
 
-  PimObjId pimObject = pimAlloc(PIM_ALLOC_AUTO, numCols, bitsPerElement, PIM_INT32);
+  PimObjId pimObject = pimAlloc(PIM_ALLOC_AUTO, numCols, PIM_INT32);
   if (pimObject == -1) {
     std::cout << "Function: " << __func__ << ", Abort: pimAlloc for PimObj pimObject failed" << std::endl;
     return;
   }
 
-  PimObjId RELUConstObj = pimAllocAssociated(bitsPerElement, pimObject, PIM_INT32);
+  PimObjId RELUConstObj = pimAllocAssociated(pimObject, PIM_INT32);
   if (RELUConstObj == -1) {
     std::cout << "Function: " << __func__ << ", Abort: pimAllocAssociated for PimObj RELUConstObj failed" << std::endl;
     return;
@@ -526,7 +520,7 @@ void performRelu(std::vector<int> &inputVector)
 // Perform the RELU (REctified Linear Unit) operation, max(0, x), a non-linear activation function in PIM for the given 2D input matrix.
 // The function allocates the necessary PIM objects, copies the data from host to PIM, and performs Max operation.
 // The max results from pimObjectList[0] are then copied from the PIM (device) to Host.
-void performRelu(const std::vector<std::vector<int>> &inputMatrix, std::vector<int> &outputMatrix, unsigned bitsPerElement)
+void performRelu(const std::vector<std::vector<int>> &inputMatrix, std::vector<int> &outputMatrix)
 {
   if (inputMatrix.empty())
   {    
@@ -539,7 +533,7 @@ void performRelu(const std::vector<std::vector<int>> &inputMatrix, std::vector<i
   std::vector<int> reluConst(numCols, 0);  
 
   std::vector<PimObjId> pimObjectList(numRows);
-  PimObjId obj1 = pimAlloc(PIM_ALLOC_AUTO, numCols, bitsPerElement, PIM_INT32);
+  PimObjId obj1 = pimAlloc(PIM_ALLOC_AUTO, numCols, PIM_INT32);
   if (obj1 == -1)
   {
     std::cout << "Function: " << __func__ << ", Abort: pimAlloc for PimObj obj1 failed" << std::endl;
@@ -548,7 +542,7 @@ void performRelu(const std::vector<std::vector<int>> &inputMatrix, std::vector<i
   pimObjectList[0] = obj1;
   for (int i = 1; i < numRows; i++)
   {
-    PimObjId obj = pimAllocAssociated(bitsPerElement, pimObjectList[0], PIM_INT32);
+    PimObjId obj = pimAllocAssociated(pimObjectList[0], PIM_INT32);
     if (obj == -1)
     {
       std::cout << "Function: " << __func__ << ", Abort: pimAllocAssociated for PimObj obj failed" << std::endl;
@@ -556,7 +550,7 @@ void performRelu(const std::vector<std::vector<int>> &inputMatrix, std::vector<i
     }
     pimObjectList[i] = obj;
   }
-  PimObjId RELUConstObj = pimAllocAssociated(bitsPerElement, pimObjectList[0], PIM_INT32);
+  PimObjId RELUConstObj = pimAllocAssociated(pimObjectList[0], PIM_INT32);
   if (RELUConstObj == -1)
   {
       std::cout << "Function: " << __func__ << ", Abort: pimAllocAssociated for PimObj RELUConstObj failed" << std::endl;
@@ -650,7 +644,7 @@ void relu (std::vector<std::vector<std::vector<int>>> &inputMatrix) {
     }
   }
   
-  performRelu(mergedMat, outVector, bitsPerElement);
+  performRelu(mergedMat, outVector);
 
   uint64_t idx = 0;
   for (int i = 0; i < inputDepth; i += 1)

--- a/PIMbench/vec-add/PIM/vec-add.cpp
+++ b/PIMbench/vec-add/PIM/vec-add.cpp
@@ -78,14 +78,13 @@ struct Params getInputParams(int argc, char **argv)
 
 void vectorAddition(uint64_t vectorLength, std::vector<int> &src1, std::vector<int> &src2, std::vector<int> &dst)
 {
-  unsigned bitsPerElement = sizeof(int) * 8;
-  PimObjId srcObj1 = pimAlloc(PIM_ALLOC_AUTO, vectorLength, bitsPerElement, PIM_INT32);
+  PimObjId srcObj1 = pimAlloc(PIM_ALLOC_AUTO, vectorLength, PIM_INT32);
   if (srcObj1 == -1)
   {
     std::cout << "Abort" << std::endl;
     return;
   }
-  PimObjId srcObj2 = pimAllocAssociated(bitsPerElement, srcObj1, PIM_INT32);
+  PimObjId srcObj2 = pimAllocAssociated(srcObj1, PIM_INT32);
   if (srcObj2 == -1)
   {
     std::cout << "Abort" << std::endl;

--- a/bit-serial/bitSerialBase.h
+++ b/bit-serial/bitSerialBase.h
@@ -227,12 +227,12 @@ bitSerialBase::testInt(const std::string& category, PimDataType dataType)
   vecSrc1[501] = static_cast<T>(scalarVal - 1); // cover scalar LT
 
   // allocate PIM objects
-  PimObjId src1 = pimAlloc(PIM_ALLOC_V1, numElements, numBits, dataType);
-  PimObjId src2 = pimAllocAssociated(numBits, src1, dataType);
-  PimObjId srcNonZero = pimAllocAssociated(numBits, src1, dataType);
-  PimObjId dest1 = pimAllocAssociated(numBits, src1, dataType);
-  PimObjId dest2 = pimAllocAssociated(numBits, src1, dataType);
-  PimObjId src3 = pimAllocAssociated(numBits, src1, dataType);  // alloc at last for oob check
+  PimObjId src1 = pimAlloc(PIM_ALLOC_V1, numElements, dataType);
+  PimObjId src2 = pimAllocAssociated(src1, dataType);
+  PimObjId srcNonZero = pimAllocAssociated(src1, dataType);
+  PimObjId dest1 = pimAllocAssociated(src1, dataType);
+  PimObjId dest2 = pimAllocAssociated(src1, dataType);
+  PimObjId src3 = pimAllocAssociated(src1, dataType);  // alloc at last for oob check
 
   // for printing. keep in sync with switch case below
   const std::vector<std::string> testNames = {
@@ -461,12 +461,12 @@ bitSerialBase::testFp(const std::string& category, PimDataType dataType)
   vecSrc2[3000] = vecSrc1[3000];
 
   // allocate PIM objects
-  PimObjId src1 = pimAlloc(PIM_ALLOC_V1, numElements, numBits, dataType);
-  PimObjId src2 = pimAllocAssociated(numBits, src1, dataType);
-  PimObjId srcNonZero = pimAllocAssociated(numBits, src1, dataType);
-  PimObjId dest1 = pimAllocAssociated(numBits, src1, dataType);
-  PimObjId dest2 = pimAllocAssociated(numBits, src1, dataType);
-  PimObjId src3 = pimAllocAssociated(numBits, src1, dataType);  // alloc at last for oob check
+  PimObjId src1 = pimAlloc(PIM_ALLOC_V1, numElements, dataType);
+  PimObjId src2 = pimAllocAssociated(src1, dataType);
+  PimObjId srcNonZero = pimAllocAssociated(src1, dataType);
+  PimObjId dest1 = pimAllocAssociated(src1, dataType);
+  PimObjId dest2 = pimAllocAssociated(src1, dataType);
+  PimObjId src3 = pimAllocAssociated(src1, dataType);  // alloc at last for oob check
 
   // for printing. keep in sync with switch case below
   const std::vector<std::string> testNames = {

--- a/bit-serial/bitSerialBitsimd.cpp
+++ b/bit-serial/bitSerialBitsimd.cpp
@@ -160,7 +160,7 @@ bitSerialBitsimd::implIntMul3Reg(int numBits, PimObjId src1, PimObjId src2, PimO
   if (numBits > 32) return; // todo
 
   std::cout << "BS-INFO: Allocate 32 temporary rows" << std::endl;
-  PimObjId tmp = pimAllocAssociated(32, src1, PIM_INT32);
+  PimObjId tmp = pimAllocAssociated(src1, PIM_INT32);
 
   // cond copy the first
   pimOpReadRowToSa(src1, 0);
@@ -266,8 +266,8 @@ bitSerialBitsimd::implIntDivRem(int numBits, PimObjId src1, PimObjId src2, PimOb
 
   // compute abs
   std::cout << "BS-INFO: Allocate 64 temporary rows" << std::endl;
-  PimObjId abs1 = pimAllocAssociated(32, src1, PIM_INT32);
-  PimObjId abs2 = pimAllocAssociated(32, src1, PIM_INT32);
+  PimObjId abs1 = pimAllocAssociated(src1, PIM_INT32);
+  PimObjId abs2 = pimAllocAssociated(src1, PIM_INT32);
   bitSerialIntAbs(numBits, src1, abs1);
   if (useScalar) {
     // broadcast the scalar value for computing abs
@@ -313,8 +313,8 @@ bitSerialBitsimd::implUintDivRem(int numBits, PimObjId src1, PimObjId src2, PimO
 
   // quotient and remainder
   std::cout << "BS-INFO: Allocate 96 temporary rows" << std::endl;
-  PimObjId qr = pimAllocAssociated(64, src1, PIM_INT64);
-  PimObjId tmp = pimAllocAssociated(32, src1, PIM_INT32);
+  PimObjId qr = pimAllocAssociated(src1, PIM_INT64);
+  PimObjId tmp = pimAllocAssociated(src1, PIM_INT32);
 
   // init 64-bit space
   pimOpSet(src1, PIM_RREG_SA, 0);

--- a/bit-serial/bitSerialBitsimdAp.cpp
+++ b/bit-serial/bitSerialBitsimdAp.cpp
@@ -231,8 +231,8 @@ bitSerialBitsimdAp::implIntDivRem(int numBits, PimObjId src1, PimObjId src2, Pim
 
   // compute abs
   std::cout << "BS-INFO: Allocate 64 temporary rows" << std::endl;
-  PimObjId abs1 = pimAllocAssociated(32, src1, PIM_INT32);
-  PimObjId abs2 = pimAllocAssociated(32, src1, PIM_INT32);
+  PimObjId abs1 = pimAllocAssociated(src1, PIM_INT32);
+  PimObjId abs2 = pimAllocAssociated(src1, PIM_INT32);
   bitSerialIntAbs(numBits, src1, abs1);
   if (useScalar) {
     // broadcast the scalar value for computing abs
@@ -282,8 +282,8 @@ bitSerialBitsimdAp::implUintDivRem(int numBits, PimObjId src1, PimObjId src2, Pi
 
   // quotient and remainder
   std::cout << "BS-INFO: Allocate 96 temporary rows" << std::endl;
-  PimObjId qr = pimAllocAssociated(64, src1, PIM_INT64);
-  PimObjId tmp = pimAllocAssociated(32, src1, PIM_INT32);
+  PimObjId qr = pimAllocAssociated(src1, PIM_INT64);
+  PimObjId tmp = pimAllocAssociated(src1, PIM_INT32);
 
   // init 64-bit space
   pimOpSet(src1, PIM_RREG_SA, 0);

--- a/libpimeval/src/libpimeval.cpp
+++ b/libpimeval/src/libpimeval.cpp
@@ -6,6 +6,7 @@
 
 #include "libpimeval.h"
 #include "pimSim.h"
+#include "pimUtils.h"
 
 
 //! @brief  Create a PIM device
@@ -56,16 +57,18 @@ pimResetStats()
 
 //! @brief  Allocate a PIM resource
 PimObjId
-pimAlloc(PimAllocEnum allocType, uint64_t numElements, unsigned bitsPerElements, PimDataType dataType)
+pimAlloc(PimAllocEnum allocType, uint64_t numElements, PimDataType dataType)
 {
-  return pimSim::get()->pimAlloc(allocType, numElements, bitsPerElements, dataType);
+  unsigned bitsPerElement = pimUtils::getNumBitsOfDataType(dataType);
+  return pimSim::get()->pimAlloc(allocType, numElements, bitsPerElement, dataType);
 }
 
 //! @brief  Allocate a PIM resource, with an associated object as reference
 PimObjId
-pimAllocAssociated(unsigned bitsPerElements, PimObjId assocId, PimDataType dataType)
+pimAllocAssociated(PimObjId assocId, PimDataType dataType)
 {
-  return pimSim::get()->pimAllocAssociated(bitsPerElements, assocId, dataType);
+  unsigned bitsPerElement = pimUtils::getNumBitsOfDataType(dataType);
+  return pimSim::get()->pimAllocAssociated(bitsPerElement, assocId, dataType);
 }
 
 //! @brief  Free a PIM resource

--- a/libpimeval/src/libpimeval.h
+++ b/libpimeval/src/libpimeval.h
@@ -82,8 +82,8 @@ void pimShowStats();
 void pimResetStats();
 
 // Resource allocation and deletion
-PimObjId pimAlloc(PimAllocEnum allocType, uint64_t numElements, unsigned bitsPerElement, PimDataType dataType);
-PimObjId pimAllocAssociated(unsigned bitsPerElement, PimObjId assocId, PimDataType dataType);
+PimObjId pimAlloc(PimAllocEnum allocType, uint64_t numElements, PimDataType dataType);
+PimObjId pimAllocAssociated(PimObjId assocId, PimDataType dataType);
 PimStatus pimFree(PimObjId obj);
 PimObjId pimCreateRangedRef(PimObjId refId, uint64_t idxBegin, uint64_t idxEnd);
 

--- a/libpimeval/src/pimUtils.cpp
+++ b/libpimeval/src/pimUtils.cpp
@@ -13,6 +13,7 @@
 #include <string>
 #include <filesystem>
 #include <cstdlib>
+#include <cassert>
 
 //! @brief  Convert PimStatus enum to string
 std::string
@@ -86,6 +87,26 @@ pimUtils::pimDataTypeEnumToStr(PimDataType dataType)
   case PIM_FP32: return "fp32";
   }
   return "Unknown";
+}
+
+//! @brief  Get number of bits of a PIM data type
+unsigned
+pimUtils::getNumBitsOfDataType(PimDataType dataType)
+{
+  switch (dataType) {
+  case PIM_INT8: return 8;
+  case PIM_INT16: return 16;
+  case PIM_INT32: return 32;
+  case PIM_INT64: return 64;
+  case PIM_UINT8: return 8;
+  case PIM_UINT16: return 16;
+  case PIM_UINT32: return 32;
+  case PIM_UINT64: return 64;
+  case PIM_FP32: return 32;
+  default:
+    assert(0);
+  }
+  return 0;
 }
 
 //! @brief  Read bits from host

--- a/libpimeval/src/pimUtils.h
+++ b/libpimeval/src/pimUtils.h
@@ -28,6 +28,7 @@ namespace pimUtils
   std::string pimAllocEnumToStr(PimAllocEnum allocType);
   std::string pimCopyEnumToStr(PimCopyEnum copyType);
   std::string pimDataTypeEnumToStr(PimDataType dataType);
+  unsigned getNumBitsOfDataType(PimDataType dataType);
   std::string& ltrim(std::string& s);
   std::string& rtrim(std::string& s);
   std::string& trim(std::string& s);

--- a/misc-bench/cpp-bitmap/PIM/bitmap.cpp
+++ b/misc-bench/cpp-bitmap/PIM/bitmap.cpp
@@ -84,12 +84,11 @@ struct Params getInputParams(int argc, char **argv)
 
 void bitmap(const uint64_t numDatabaseEntries, const std::vector<uint8_t> database, const std::vector<uint8_t> indicesChecker, std::vector<std::vector<uint8_t>> &result)
 {
-  unsigned bitsPerElement = sizeof(uint8_t) * 8; 
-  PimObjId databaseObj = pimAlloc(PIM_ALLOC_AUTO, numDatabaseEntries, bitsPerElement, PIM_UINT8);
+  PimObjId databaseObj = pimAlloc(PIM_ALLOC_AUTO, numDatabaseEntries, PIM_UINT8);
   assert(databaseObj != -1);
-  PimObjId indicesCheckerObj = pimAllocAssociated(bitsPerElement, databaseObj, PIM_UINT8);
+  PimObjId indicesCheckerObj = pimAllocAssociated(databaseObj, PIM_UINT8);
   assert(indicesCheckerObj != -1);
-  PimObjId tempObj = pimAllocAssociated(bitsPerElement, databaseObj, PIM_UINT8);
+  PimObjId tempObj = pimAllocAssociated(databaseObj, PIM_UINT8);
   assert(tempObj != -1);
 
   PimStatus status = pimCopyHostToDevice((void *) database.data(), databaseObj);
@@ -151,7 +150,7 @@ int main(int argc, char *argv[])
     return 1;
   }
 
-  printf("Performing bitmap with %lu data points and 8 unique bitmap indices\n", numDatabaseEntries);
+  printf("Performing bitmap with %llu data points and 8 unique bitmap indices\n", numDatabaseEntries);
 
   if (!createDevice(params.configFile))
   {

--- a/misc-bench/cpp-convolution-batch/conv-batch.cpp
+++ b/misc-bench/cpp-convolution-batch/conv-batch.cpp
@@ -147,10 +147,9 @@ void getDecomposedMatrix(int matrixRow, int matrixColumn, int filterRow, int fil
 
 void performConv(std::vector<std::vector<int>> &filterMatrix, std::vector<std::vector<int>> &inputMatrix, std::vector<int> &outputMatrix, int numRequiredPIMRows, int numRequiredPIMCol, bool moreDebugPrints)
 {
-  unsigned bitsPerElement = 32;
   std::vector<PimObjId> filterObjects;
   std::vector<int> temp;
-  PimObjId obj1 = pimAlloc(PIM_ALLOC_AUTO, numRequiredPIMCol, bitsPerElement, PIM_INT32);
+  PimObjId obj1 = pimAlloc(PIM_ALLOC_AUTO, numRequiredPIMCol, PIM_INT32);
   if (obj1 == -1)
   {
     std::cout << "Abort" << std::endl;
@@ -159,7 +158,7 @@ void performConv(std::vector<std::vector<int>> &filterMatrix, std::vector<std::v
   filterObjects.push_back(obj1);
   for (int i = 1; i < numRequiredPIMRows; i++)
   {
-    PimObjId obj = pimAllocAssociated(bitsPerElement, filterObjects[0], PIM_INT32);
+    PimObjId obj = pimAllocAssociated(filterObjects[0], PIM_INT32);
     if (obj == -1)
     {
       std::cout << "Abort" << std::endl;
@@ -185,7 +184,7 @@ void performConv(std::vector<std::vector<int>> &filterMatrix, std::vector<std::v
   std::vector<PimObjId> matrixObjects;
   for (int i = 0; i < numRequiredPIMRows; i++)
   {
-    PimObjId obj = pimAllocAssociated(bitsPerElement, filterObjects[0], PIM_INT32);
+    PimObjId obj = pimAllocAssociated(filterObjects[0], PIM_INT32);
     if (obj == -1)
     {
       std::cout << "Abort" << std::endl;

--- a/misc-bench/cpp-copy/PIM/copy.cpp
+++ b/misc-bench/cpp-copy/PIM/copy.cpp
@@ -79,11 +79,10 @@ struct Params getInputParams(int argc, char **argv)
 
 void copy(uint64_t vectorLength, const std::vector<int> &src_host, std::vector<int> &dst_host)
 {
-  unsigned bitsPerElement = sizeof(int) * 8;
-  PimObjId src_pim = pimAlloc(PIM_ALLOC_AUTO, vectorLength, bitsPerElement, PIM_INT32);
+  PimObjId src_pim = pimAlloc(PIM_ALLOC_AUTO, vectorLength, PIM_INT32);
   assert(src_pim != -1);
 
-  PimObjId dst_pim = pimAllocAssociated(bitsPerElement, src_pim, PIM_INT32);
+  PimObjId dst_pim = pimAllocAssociated(src_pim, PIM_INT32);
   assert(dst_pim != -1);
 
   PimStatus status = pimCopyHostToDevice((void *)src_host.data(), src_pim);

--- a/misc-bench/cpp-dot-prod/dot-prod.cpp
+++ b/misc-bench/cpp-dot-prod/dot-prod.cpp
@@ -80,14 +80,13 @@ struct Params getInputParams(int argc, char **argv)
 
 void dotProduct(uint64_t vectorLength, std::vector<int> &src1, std::vector<int> &src2, int64_t &result)
 {
-  unsigned bitsPerElement = sizeof(int) * 8;
-  PimObjId srcObj1 = pimAlloc(PIM_ALLOC_AUTO, vectorLength, bitsPerElement, PIM_INT32);
+  PimObjId srcObj1 = pimAlloc(PIM_ALLOC_AUTO, vectorLength, PIM_INT32);
   if (srcObj1 == -1)
   {
     std::cout << "Abort" << std::endl;
     return;
   }
-  PimObjId srcObj2 = pimAllocAssociated(bitsPerElement, srcObj1, PIM_INT32);
+  PimObjId srcObj2 = pimAllocAssociated(srcObj1, PIM_INT32);
   if (srcObj2 == -1)
   {
     std::cout << "Abort" << std::endl;

--- a/misc-bench/cpp-gemm-alt/gemm.cpp
+++ b/misc-bench/cpp-gemm-alt/gemm.cpp
@@ -86,21 +86,20 @@ struct Params getInputParams(int argc, char **argv)
 
 void gemv(uint64_t row, uint64_t col, std::vector<int> &srcVector, std::vector<std::vector<int>> &srcMatrix, std::vector<int64_t> &dst)
 {
-  unsigned bitsPerElement = sizeof(int) * 8;
-  PimObjId srcObj1 = pimAlloc(PIM_ALLOC_AUTO, col, bitsPerElement, PIM_INT32);
+  PimObjId srcObj1 = pimAlloc(PIM_ALLOC_AUTO, col, PIM_INT32);
   if (srcObj1 == -1)
   {
     std::cout << "Abort" << std::endl;
     return;
   }
-  PimObjId srcObj2 = pimAllocAssociated(bitsPerElement, srcObj1, PIM_INT32);
+  PimObjId srcObj2 = pimAllocAssociated(srcObj1, PIM_INT32);
   if (srcObj2 == -1)
   {
     std::cout << "Abort" << std::endl;
     return;
   }
 
-  PimObjId dstObj = pimAllocAssociated(bitsPerElement, srcObj1, PIM_INT32);
+  PimObjId dstObj = pimAllocAssociated(srcObj1, PIM_INT32);
   if (dstObj == -1)
   {
     std::cout << "Abort" << std::endl;

--- a/misc-bench/cpp-gemm-batch/PIM/gemm.cpp
+++ b/misc-bench/cpp-gemm-batch/PIM/gemm.cpp
@@ -86,28 +86,27 @@ struct Params getInputParams(int argc, char **argv)
 
 void gemvBatched(uint64_t row, uint64_t col, std::vector<std::vector<int>> &srcVector, std::vector<std::vector<int>> &srcMatrix, std::vector<int> &dst)
 {
-  unsigned bitsPerElement = sizeof(int) * 8;
-  PimObjId srcObj1 = pimAlloc(PIM_ALLOC_AUTO, row, bitsPerElement, PIM_INT32);
+  PimObjId srcObj1 = pimAlloc(PIM_ALLOC_AUTO, row, PIM_INT32);
   if (srcObj1 == -1)
   {
     std::cout << "Abort" << std::endl;
     return;
   }
-  PimObjId srcObj2 = pimAllocAssociated(bitsPerElement, srcObj1, PIM_INT32);
+  PimObjId srcObj2 = pimAllocAssociated(srcObj1, PIM_INT32);
   if (srcObj2 == -1)
   {
     std::cout << "Abort" << std::endl;
     return;
   }
 
-  PimObjId dstObj = pimAllocAssociated(bitsPerElement, srcObj1, PIM_INT32);
+  PimObjId dstObj = pimAllocAssociated(srcObj1, PIM_INT32);
   if (dstObj == -1)
   {
     std::cout << "Abort" << std::endl;
     return;
   }
 
-  PimObjId dstObj1 = pimAllocAssociated(bitsPerElement, srcObj1, PIM_INT32);
+  PimObjId dstObj1 = pimAllocAssociated(srcObj1, PIM_INT32);
   if (dstObj1 == -1)
   {
     std::cout << "Abort" << std::endl;

--- a/misc-bench/cpp-gemv-alt/gemv.cpp
+++ b/misc-bench/cpp-gemv-alt/gemv.cpp
@@ -81,21 +81,20 @@ struct Params getInputParams(int argc, char **argv)
 
 void gemv(uint64_t row, uint64_t col, std::vector<int> &srcVector, std::vector<std::vector<int>> &srcMatrix, std::vector<int64_t> &dst)
 {
-  unsigned bitsPerElement = sizeof(int) * 8;
-  PimObjId srcObj1 = pimAlloc(PIM_ALLOC_AUTO, col, bitsPerElement, PIM_INT32);
+  PimObjId srcObj1 = pimAlloc(PIM_ALLOC_AUTO, col, PIM_INT32);
   if (srcObj1 == -1)
   {
     std::cout << "Abort" << std::endl;
     return;
   }
-  PimObjId srcObj2 = pimAllocAssociated(bitsPerElement, srcObj1, PIM_INT32);
+  PimObjId srcObj2 = pimAllocAssociated(srcObj1, PIM_INT32);
   if (srcObj2 == -1)
   {
     std::cout << "Abort" << std::endl;
     return;
   }
 
-  PimObjId dstObj = pimAllocAssociated(bitsPerElement, srcObj1, PIM_INT32);
+  PimObjId dstObj = pimAllocAssociated(srcObj1, PIM_INT32);
   if (dstObj == -1)
   {
     std::cout << "Abort" << std::endl;

--- a/misc-bench/cpp-pooling-batch/pool-batch.cpp
+++ b/misc-bench/cpp-pooling-batch/pool-batch.cpp
@@ -135,8 +135,6 @@ void getDecomposedMatrix(int matrixRow, int matrixColumn, int kernelHeight, int 
 */
 void maxPool(const std::vector<std::vector<int>> &inputMatrix, std::vector<int> &outputMatrix)
 {
-  unsigned bitsPerElement = 32;
-
   if (inputMatrix.empty())
   {
     return;
@@ -145,7 +143,7 @@ void maxPool(const std::vector<std::vector<int>> &inputMatrix, std::vector<int> 
   int numCols = inputMatrix[0].size();
 
   std::vector<PimObjId> pimObjectList(numRows);
-  PimObjId obj1 = pimAlloc(PIM_ALLOC_AUTO, numCols, bitsPerElement, PIM_INT32);
+  PimObjId obj1 = pimAlloc(PIM_ALLOC_AUTO, numCols, PIM_INT32);
   if (obj1 == -1)
   {
     std::cout << "Abort" << std::endl;
@@ -154,7 +152,7 @@ void maxPool(const std::vector<std::vector<int>> &inputMatrix, std::vector<int> 
   pimObjectList[0] = obj1;
   for (int i = 1; i < numRows; i++)
   {
-    PimObjId obj = pimAllocAssociated(bitsPerElement, pimObjectList[0], PIM_INT32);
+    PimObjId obj = pimAllocAssociated(pimObjectList[0], PIM_INT32);
     if (obj == -1)
     {
       std::cout << "Abort" << std::endl;

--- a/misc-bench/cpp-prefix-sum/prefix-sum.cpp
+++ b/misc-bench/cpp-prefix-sum/prefix-sum.cpp
@@ -79,11 +79,10 @@ struct Params getInputParams(int argc, char **argv)
 
 void prefixSum(vector<int> &input, vector<int> &deviceoutput, uint64_t len)
 {
-  unsigned bitsPerElement = sizeof(int) * 8;
   std::vector<PimObjId> temp(len);
   std::vector<PimObjId> acc(len);
 
-  PimObjId inputObj = pimAlloc(PIM_ALLOC_AUTO, len, bitsPerElement, PIM_INT32);
+  PimObjId inputObj = pimAlloc(PIM_ALLOC_AUTO, len, PIM_INT32);
   if (inputObj == -1)
   {
     std::cerr << "Abort: Failed to allocate memory on PIM." << std::endl;
@@ -96,7 +95,7 @@ void prefixSum(vector<int> &input, vector<int> &deviceoutput, uint64_t len)
     std::cerr << "Abort: Failed to copy data to PIM." << std::endl;
     return;
   }
-  PimObjId tempObj = pimAllocAssociated(bitsPerElement, inputObj, PIM_INT32);
+  PimObjId tempObj = pimAllocAssociated(inputObj, PIM_INT32);
   if (tempObj == -1)
   {
     std::cerr << "Abort: Failed to allocate memory on PIM." << std::endl;
@@ -109,7 +108,7 @@ void prefixSum(vector<int> &input, vector<int> &deviceoutput, uint64_t len)
     return;
   }
 
-  PimObjId accObj = pimAllocAssociated(bitsPerElement, inputObj, PIM_INT32);
+  PimObjId accObj = pimAllocAssociated(inputObj, PIM_INT32);
   if (accObj == -1)
   {
     std::cerr << "Abort: Failed to allocate memory on PIM." << std::endl;
@@ -123,7 +122,7 @@ void prefixSum(vector<int> &input, vector<int> &deviceoutput, uint64_t len)
     return;
   }
 
-  PimObjId outputObj = pimAllocAssociated(bitsPerElement, inputObj, PIM_INT32);
+  PimObjId outputObj = pimAllocAssociated(inputObj, PIM_INT32);
   if (outputObj == -1)
   {
     std::cerr << "Abort: Failed to allocate memory on PIM." << std::endl;

--- a/misc-bench/cpp-relu-batch/relu_batch.cpp
+++ b/misc-bench/cpp-relu-batch/relu_batch.cpp
@@ -125,8 +125,6 @@ void decomposeMatrix(int matrixRow, int matrixColumn, int kernelHeight, int kern
 */
 void performRelu(const std::vector<std::vector<int>> &inputMatrix, std::vector<int> &outputMatrix)
 {
-  unsigned bitsPerElement = 32;
-
   if (inputMatrix.empty())
   {
     std::cout << "Function: " << __func__ << ", Abort: Input matrix is empty" << std::endl;
@@ -138,7 +136,7 @@ void performRelu(const std::vector<std::vector<int>> &inputMatrix, std::vector<i
   uint64_t reluConst = 0;  
 
   std::vector<PimObjId> pimObjectList(numRows);
-  PimObjId obj1 = pimAlloc(PIM_ALLOC_AUTO, numCols, bitsPerElement, PIM_INT32);
+  PimObjId obj1 = pimAlloc(PIM_ALLOC_AUTO, numCols, PIM_INT32);
   if (obj1 == -1)
   {
     std::cout << "Abort: pimAlloc for PimObj obj1 failed" << std::endl;
@@ -147,7 +145,7 @@ void performRelu(const std::vector<std::vector<int>> &inputMatrix, std::vector<i
   pimObjectList[0] = obj1;
   for (int i = 1; i < numRows; i++)
   {
-    PimObjId obj = pimAllocAssociated(bitsPerElement, pimObjectList[0], PIM_INT32);
+    PimObjId obj = pimAllocAssociated(pimObjectList[0], PIM_INT32);
     if (obj == -1)
     {
       std::cout << "Abort: pimAllocAssociated for PimObj obj failed" << std::endl;

--- a/misc-bench/cpp-sad/sad.cpp
+++ b/misc-bench/cpp-sad/sad.cpp
@@ -23,21 +23,20 @@ int main()
     return 1;
   }
 
-  int bitsPerElement = 32;
   int vectorLength = 512;
   int subvectorLength = 64;
 
-  PimObjId obj1 = pimAlloc(PIM_ALLOC_AUTO, vectorLength, bitsPerElement, PIM_INT32);
+  PimObjId obj1 = pimAlloc(PIM_ALLOC_AUTO, vectorLength, PIM_INT32);
   if (obj1 == -1) {
     std::cout << "Abort" << std::endl;
     return 1;
   }
-  PimObjId obj2 = pimAllocAssociated(bitsPerElement, obj1, PIM_INT32);
+  PimObjId obj2 = pimAllocAssociated(obj1, PIM_INT32);
   if (obj2 == -1) {
     std::cout << "Abort" << std::endl;
     return 1;
   }
-  PimObjId obj3 = pimAllocAssociated(bitsPerElement, obj1, PIM_INT32);
+  PimObjId obj3 = pimAllocAssociated(obj1, PIM_INT32);
   if (obj3 == -1) {
     std::cout << "Abort" << std::endl;
     return 1;

--- a/misc-bench/cpp-scale/PIM/scale.cpp
+++ b/misc-bench/cpp-scale/PIM/scale.cpp
@@ -79,11 +79,10 @@ struct Params getInputParams(int argc, char **argv)
 
 void scale(uint64_t vectorLength, const std::vector<int> &src_host, int A, std::vector<int> &dst_host)
 {
-  unsigned bitsPerElement = sizeof(int) * 8;
-  PimObjId src_pim = pimAlloc(PIM_ALLOC_AUTO, vectorLength, bitsPerElement, PIM_INT32);
+  PimObjId src_pim = pimAlloc(PIM_ALLOC_AUTO, vectorLength, PIM_INT32);
   assert(src_pim != -1);
 
-  PimObjId dst_pim = pimAllocAssociated(bitsPerElement, dst_pim, PIM_INT32);
+  PimObjId dst_pim = pimAllocAssociated(src_pim, PIM_INT32);
   assert(dst_pim != -1);
 
   PimStatus status = pimCopyHostToDevice((void *)src_host.data(), src_pim);

--- a/misc-bench/cpp-transitive-closure/PIM/transitive-closure.cpp
+++ b/misc-bench/cpp-transitive-closure/PIM/transitive-closure.cpp
@@ -88,14 +88,13 @@ struct Params getInputParams(int argc, char **argv)
 
 void transitiveClosure(std::vector<uint16_t> &adjList, int numVertices)
 {
-  int bitsPerElement = sizeof(uint16_t) * 8;
-  PimObjId adjListObj = pimAlloc(PIM_ALLOC_AUTO, numVertices * numVertices, bitsPerElement, PIM_UINT16);
+  PimObjId adjListObj = pimAlloc(PIM_ALLOC_AUTO, numVertices * numVertices, PIM_UINT16);
   assert(adjListObj != -1);
-  PimObjId keyObj = pimAllocAssociated(bitsPerElement, adjListObj, PIM_UINT16);
+  PimObjId keyObj = pimAllocAssociated(adjListObj, PIM_UINT16);
   assert(keyObj != -1);
-  PimObjId additionObj = pimAllocAssociated(bitsPerElement, adjListObj, PIM_UINT16);
+  PimObjId additionObj = pimAllocAssociated(adjListObj, PIM_UINT16);
   assert(additionObj != -1);
-  PimObjId tempObj = pimAllocAssociated(bitsPerElement, adjListObj, PIM_UINT16);
+  PimObjId tempObj = pimAllocAssociated(adjListObj, PIM_UINT16);
   assert(tempObj != -1);
 
   PimStatus status = pimCopyHostToDevice((void *) adjList.data(), adjListObj);

--- a/misc-bench/cpp-vec-add-fp32/vec-add-fp32.cpp
+++ b/misc-bench/cpp-vec-add-fp32/vec-add-fp32.cpp
@@ -78,14 +78,13 @@ struct Params getInputParams(int argc, char **argv)
 
 void vectorAddition(uint64_t vectorLength, std::vector<float> &src1, std::vector<float> &src2, std::vector<float> &dst)
 {
-  unsigned bitsPerElement = sizeof(float) * 8;
-  PimObjId srcObj1 = pimAlloc(PIM_ALLOC_AUTO, vectorLength, bitsPerElement, PIM_FP32);
+  PimObjId srcObj1 = pimAlloc(PIM_ALLOC_AUTO, vectorLength, PIM_FP32);
   if (srcObj1 == -1)
   {
     std::cout << "Abort" << std::endl;
     return;
   }
-  PimObjId srcObj2 = pimAllocAssociated(bitsPerElement, srcObj1, PIM_FP32);
+  PimObjId srcObj2 = pimAllocAssociated(srcObj1, PIM_FP32);
   if (srcObj2 == -1)
   {
     std::cout << "Abort" << std::endl;

--- a/misc-bench/cpp-vec-arithmetic/vec-arithmetic.cpp
+++ b/misc-bench/cpp-vec-arithmetic/vec-arithmetic.cpp
@@ -37,19 +37,18 @@ int main(int argc, char *argv[])
 #endif
 
   unsigned numElements = 512;
-  unsigned bitsPerElement = 32;
 
-  PimObjId obj1 = pimAlloc(PIM_ALLOC_AUTO, numElements, bitsPerElement, PIM_INT32);
+  PimObjId obj1 = pimAlloc(PIM_ALLOC_AUTO, numElements, PIM_INT32);
   if (obj1 == -1) {
     std::cout << "Abort" << std::endl;
     return 1;
   }
-  PimObjId obj2 = pimAllocAssociated(bitsPerElement, obj1, PIM_INT32);
+  PimObjId obj2 = pimAllocAssociated(obj1, PIM_INT32);
   if (obj2 == -1) {
     std::cout << "Abort" << std::endl;
     return 1;
   }
-  PimObjId obj3 = pimAllocAssociated(bitsPerElement, obj1, PIM_INT32);
+  PimObjId obj3 = pimAllocAssociated(obj1, PIM_INT32);
   if (obj3 == -1) {
     std::cout << "Abort" << std::endl;
     return 1;

--- a/misc-bench/cpp-vec-comp/vec-comparator.cpp
+++ b/misc-bench/cpp-vec-comp/vec-comparator.cpp
@@ -22,19 +22,18 @@ int main()
   }
 
   unsigned numElements = 512;
-  unsigned bitsPerElement = 32;
 
-  PimObjId obj1 = pimAlloc(PIM_ALLOC_AUTO, numElements, bitsPerElement, PIM_INT32);
+  PimObjId obj1 = pimAlloc(PIM_ALLOC_AUTO, numElements, PIM_INT32);
   if (obj1 == -1) {
     std::cout << "Abort" << std::endl;
     return 1;
   }
-  PimObjId obj2 = pimAllocAssociated(bitsPerElement, obj1, PIM_INT32);
+  PimObjId obj2 = pimAllocAssociated(obj1, PIM_INT32);
   if (obj2 == -1) {
     std::cout << "Abort" << std::endl;
     return 1;
   }
-  PimObjId obj3 = pimAllocAssociated(bitsPerElement, obj1, PIM_INT32);
+  PimObjId obj3 = pimAllocAssociated(obj1, PIM_INT32);
   if (obj3 == -1) {
     std::cout << "Abort" << std::endl;
     return 1;

--- a/misc-bench/cpp-vec-div/vec-div.cpp
+++ b/misc-bench/cpp-vec-div/vec-div.cpp
@@ -79,14 +79,13 @@ struct Params getInputParams(int argc, char **argv)
 
 void vectorDiv(uint64_t vectorLength, std::vector<int> &src1, std::vector<int> &src2, std::vector<int> &dst)
 {
-  unsigned bitsPerElement = sizeof(int) * 8;
-  PimObjId srcObj1 = pimAlloc(PIM_ALLOC_AUTO, vectorLength, bitsPerElement, PIM_INT32);
+  PimObjId srcObj1 = pimAlloc(PIM_ALLOC_AUTO, vectorLength, PIM_INT32);
   if (srcObj1 == -1)
   {
     std::cout << "Abort" << std::endl;
     return;
   }
-  PimObjId srcObj2 = pimAllocAssociated(bitsPerElement, srcObj1, PIM_INT32);
+  PimObjId srcObj2 = pimAllocAssociated(srcObj1, PIM_INT32);
   if (srcObj2 == -1)
   {
     std::cout << "Abort" << std::endl;

--- a/misc-bench/cpp-vec-logical/vec-logical.cpp
+++ b/misc-bench/cpp-vec-logical/vec-logical.cpp
@@ -22,19 +22,18 @@ int main()
   }
 
   unsigned numElements = 512;
-  unsigned bitsPerElement = 32;
 
-  PimObjId obj1 = pimAlloc(PIM_ALLOC_AUTO, numElements, bitsPerElement, PIM_INT32);
+  PimObjId obj1 = pimAlloc(PIM_ALLOC_AUTO, numElements, PIM_INT32);
   if (obj1 == -1) {
     std::cout << "Abort" << std::endl;
     return 1;
   }
-  PimObjId obj2 = pimAllocAssociated(bitsPerElement, obj1, PIM_INT32);
+  PimObjId obj2 = pimAllocAssociated(obj1, PIM_INT32);
   if (obj2 == -1) {
     std::cout << "Abort" << std::endl;
     return 1;
   }
-  PimObjId obj3 = pimAllocAssociated(bitsPerElement, obj1, PIM_INT32);
+  PimObjId obj3 = pimAllocAssociated(obj1, PIM_INT32);
   if (obj3 == -1) {
     std::cout << "Abort" << std::endl;
     return 1;

--- a/misc-bench/cpp-vec-mul-fp32/vec-mul-fp32.cpp
+++ b/misc-bench/cpp-vec-mul-fp32/vec-mul-fp32.cpp
@@ -79,14 +79,13 @@ struct Params getInputParams(int argc, char **argv)
 
 void vectorMul(uint64_t vectorLength, std::vector<float> &src1, std::vector<float> &src2, std::vector<float> &dst)
 {
-  unsigned bitsPerElement = sizeof(int) * 8;
-  PimObjId srcObj1 = pimAlloc(PIM_ALLOC_AUTO, vectorLength, bitsPerElement, PIM_FP32);
+  PimObjId srcObj1 = pimAlloc(PIM_ALLOC_AUTO, vectorLength, PIM_FP32);
   if (srcObj1 == -1)
   {
     std::cout << "Abort" << std::endl;
     return;
   }
-  PimObjId srcObj2 = pimAllocAssociated(bitsPerElement, srcObj1, PIM_FP32);
+  PimObjId srcObj2 = pimAllocAssociated(srcObj1, PIM_FP32);
   if (srcObj2 == -1)
   {
     std::cout << "Abort" << std::endl;

--- a/misc-bench/cpp-vec-mul/vec-mul.cpp
+++ b/misc-bench/cpp-vec-mul/vec-mul.cpp
@@ -79,14 +79,13 @@ struct Params getInputParams(int argc, char **argv)
 
 void vectorMul(uint64_t vectorLength, std::vector<int> &src1, std::vector<int> &src2, std::vector<int> &dst)
 {
-  unsigned bitsPerElement = sizeof(int) * 8;
-  PimObjId srcObj1 = pimAlloc(PIM_ALLOC_AUTO, vectorLength, bitsPerElement, PIM_INT32);
+  PimObjId srcObj1 = pimAlloc(PIM_ALLOC_AUTO, vectorLength, PIM_INT32);
   if (srcObj1 == -1)
   {
     std::cout << "Abort" << std::endl;
     return;
   }
-  PimObjId srcObj2 = pimAllocAssociated(bitsPerElement, srcObj1, PIM_INT32);
+  PimObjId srcObj2 = pimAllocAssociated(srcObj1, PIM_INT32);
   if (srcObj2 == -1)
   {
     std::cout << "Abort" << std::endl;

--- a/misc-bench/cpp-vec-popcnt/popcount.cpp
+++ b/misc-bench/cpp-vec-popcnt/popcount.cpp
@@ -78,8 +78,7 @@ struct Params getInputParams(int argc, char **argv)
 
 void vectorPopCount(uint64_t vectorLength, std::vector<int> &src1, std::vector<int> &dst)
 {
-  unsigned bitsPerElement = sizeof(int) * 8;
-  PimObjId srcObj = pimAlloc(PIM_ALLOC_AUTO, vectorLength, bitsPerElement, PIM_INT32);
+  PimObjId srcObj = pimAlloc(PIM_ALLOC_AUTO, vectorLength, PIM_INT32);
   if (srcObj == -1)
   {
     std::cout << "Abort" << std::endl;

--- a/misc-bench/cpp-vec-reduction/vec-red.cpp
+++ b/misc-bench/cpp-vec-reduction/vec-red.cpp
@@ -79,8 +79,7 @@ struct Params getInputParams(int argc, char **argv)
 
 void vectorRed(uint64_t vectorLength, std::vector<int> src, int64_t &reductionValue)
 {
-  unsigned bitsPerElement = sizeof(int) * 8;
-  PimObjId srcObj = pimAlloc(PIM_ALLOC_AUTO, vectorLength, bitsPerElement, PIM_INT32);
+  PimObjId srcObj = pimAlloc(PIM_ALLOC_AUTO, vectorLength, PIM_INT32);
   if (srcObj == -1)
   {
     std::cout << "Abort" << std::endl;

--- a/misc-bench/cpp-vec-xor/PIM/xor.cpp
+++ b/misc-bench/cpp-vec-xor/PIM/xor.cpp
@@ -83,12 +83,11 @@ struct Params getInputParams(int argc, char **argv)
 
 void XOR(uint64_t vectorLength, const std::vector<int> src1, const std::vector<int> src2, std::vector<int> &dst)
 {
-  unsigned bitsPerElement = sizeof(int) * 8; 
-  PimObjId srcObj1 = pimAlloc(PIM_ALLOC_AUTO, vectorLength, bitsPerElement, PIM_INT32);
+  PimObjId srcObj1 = pimAlloc(PIM_ALLOC_AUTO, vectorLength, PIM_INT32);
   assert(srcObj1 != -1);
-  PimObjId srcObj2 = pimAllocAssociated(bitsPerElement, srcObj1, PIM_INT32);
+  PimObjId srcObj2 = pimAllocAssociated(srcObj1, PIM_INT32);
   assert(srcObj2 != -1);
-  PimObjId dstObj = pimAllocAssociated(bitsPerElement, srcObj1, PIM_INT32);
+  PimObjId dstObj = pimAllocAssociated(srcObj1, PIM_INT32);
   assert(dstObj != -1);
 
   PimStatus status = pimCopyHostToDevice((void *) src1.data(), srcObj1);
@@ -128,7 +127,7 @@ int main(int argc, char *argv[])
     return 1;
   }
 
-  printf("Performing XOR with %lu data points\n", vectorLength);
+  printf("Performing XOR with %llu data points\n", vectorLength);
 
   if (!createDevice(params.configFile))
   {

--- a/misc-bench/utilML.h
+++ b/misc-bench/utilML.h
@@ -100,10 +100,9 @@ void softmaxOnHost(const std::vector<T> &input, std::vector<double> &output)
 // The summed results are then copied from the PIM (device) to Host.
 void performConv(std::vector<std::vector<int>> &filterMatrix, std::vector<std::vector<int>> &inputMatrix, std::vector<int> &outputMatrix, int numRequiredPIMRows, int numRequiredPIMCol)
 {
-  unsigned bitsPerElement = 32;
   std::vector<PimObjId> filterObjects;
   std::vector<int> temp;
-  PimObjId obj1 = pimAlloc(PIM_ALLOC_AUTO, numRequiredPIMCol, bitsPerElement, PIM_INT32);
+  PimObjId obj1 = pimAlloc(PIM_ALLOC_AUTO, numRequiredPIMCol, PIM_INT32);
   if (obj1 == -1)
   {
     std::cout << "Function: " << __func__ << "Abort: pimAlloc failed for obj1" << std::endl;
@@ -112,7 +111,7 @@ void performConv(std::vector<std::vector<int>> &filterMatrix, std::vector<std::v
   filterObjects.push_back(obj1);
   for (int i = 1; i < numRequiredPIMRows; i++)
   {
-    PimObjId obj = pimAllocAssociated(bitsPerElement, filterObjects[0], PIM_INT32);
+    PimObjId obj = pimAllocAssociated(filterObjects[0], PIM_INT32);
     if (obj == -1)
     {
       std::cout << "Function: " << __func__ << "Abort: pimAllocAssociated failed for obj at i=" << i << std::endl;
@@ -138,7 +137,7 @@ void performConv(std::vector<std::vector<int>> &filterMatrix, std::vector<std::v
   std::vector<PimObjId> matrixObjects;
   for (int i = 0; i < numRequiredPIMRows; i++)
   {
-    PimObjId obj = pimAllocAssociated(bitsPerElement, filterObjects[0], PIM_INT32);
+    PimObjId obj = pimAllocAssociated(filterObjects[0], PIM_INT32);
     if (obj == -1)
     {
       std::cout << "Function: " << __func__ << "Abort: pimAllocAssociated failed for obj at i=" << i << std::endl;
@@ -279,8 +278,6 @@ void conv2(std::vector<std::vector<std::vector<int>>> &inputMatrix, std::vector<
 // The max results from pimObjectList[0] are then copied from the PIM (device) to Host.
 void maxPool(const std::vector<std::vector<int>> &inputMatrix, std::vector<int> &outputMatrix)
 {
-  unsigned bitsPerElement = 32;
-
   if (inputMatrix.empty())
   {
     return;
@@ -289,7 +286,7 @@ void maxPool(const std::vector<std::vector<int>> &inputMatrix, std::vector<int> 
   int numCols = inputMatrix[0].size();
 
   std::vector<PimObjId> pimObjectList(numRows);
-  PimObjId obj1 = pimAlloc(PIM_ALLOC_AUTO, numCols, bitsPerElement, PIM_INT32);
+  PimObjId obj1 = pimAlloc(PIM_ALLOC_AUTO, numCols, PIM_INT32);
   if (obj1 == -1)
   {
     std::cout << "Function: " << __func__ << "Abort: pimAlloc failed for obj1" << std::endl;
@@ -298,7 +295,7 @@ void maxPool(const std::vector<std::vector<int>> &inputMatrix, std::vector<int> 
   pimObjectList[0] = obj1;
   for (int i = 1; i < numRows; i++)
   {
-    PimObjId obj = pimAllocAssociated(bitsPerElement, pimObjectList[0], PIM_INT32);
+    PimObjId obj = pimAllocAssociated(pimObjectList[0], PIM_INT32);
     if (obj == -1)
     {
       std::cout << "Function: " << __func__ << "Abort: pimAllocAssociated failed for obj at i=" << i << std::endl;
@@ -395,15 +392,14 @@ void pool(std::vector<std::vector<std::vector<int>>> &inputMatrix, int kernelHei
 // The accumulated results are then copied from the PIM (device) to the host. 
 void gemv(uint64_t row, uint64_t col, std::vector<int> &srcVector, std::vector<std::vector<int>> &srcMatrix, std::vector<int> &dst)
 {
-  unsigned bitsPerElement = sizeof(int) * 8;
-  PimObjId srcObj = pimAlloc(PIM_ALLOC_AUTO, row, bitsPerElement, PIM_INT32);
+  PimObjId srcObj = pimAlloc(PIM_ALLOC_AUTO, row, PIM_INT32);
   if (srcObj == -1)
   {
     std::cout << "Function: " << __func__ << ", Abort: pimAlloc failed for srcObj" << std::endl;
     return;
   }
 
-  PimObjId dstObj = pimAllocAssociated(bitsPerElement, srcObj, PIM_INT32);
+  PimObjId dstObj = pimAllocAssociated(srcObj, PIM_INT32);
   if (dstObj == -1)
   {
     std::cout << "Function: " << __func__ << ", Abort: pimAllocAssociated failed for dstObj" << std::endl;
@@ -456,8 +452,6 @@ void gemv(uint64_t row, uint64_t col, std::vector<int> &srcVector, std::vector<s
 // The max results from pimObject are then copied from the PIM (device) to Host.
 void performRelu(std::vector<int> &inputMatrix)
 {
-  unsigned bitsPerElement = 32;
-
   if (inputMatrix.empty()) {
     std::cout << "Function: " << __func__ << ", Abort: Input matrix is empty" << std::endl;    
     return;
@@ -467,13 +461,13 @@ void performRelu(std::vector<int> &inputMatrix)
   // Initialize reluConst vector with zero for max(0, x) operation.
   std::vector<int> reluConst(numCols, 0);  
 
-  PimObjId pimObject = pimAlloc(PIM_ALLOC_AUTO, numCols, bitsPerElement, PIM_INT32);
+  PimObjId pimObject = pimAlloc(PIM_ALLOC_AUTO, numCols, PIM_INT32);
   if (pimObject == -1) {
     std::cout << "Function: " << __func__ << ", Abort: pimAlloc for PimObj pimObject failed" << std::endl;
     return;
   }
 
-  PimObjId RELUConstObj = pimAllocAssociated(bitsPerElement, pimObject, PIM_INT32);
+  PimObjId RELUConstObj = pimAllocAssociated(pimObject, PIM_INT32);
   if (RELUConstObj == -1) {
     std::cout << "Function: " << __func__ << ", Abort: pimAllocAssociated for PimObj RELUConstObj failed" << std::endl;
     return;
@@ -514,8 +508,6 @@ void performRelu(std::vector<int> &inputMatrix)
 // The max results from pimObjectList[0] are then copied from the PIM (device) to Host.
 void performRelu(const std::vector<std::vector<int>> &inputMatrix, std::vector<int> &outputMatrix)
 {
-  unsigned bitsPerElement = 32;
-
   if (inputMatrix.empty())
   {    
     std::cout << "Function: " << __func__ << ", Abort: Input matrix is empty" << std::endl;
@@ -527,7 +519,7 @@ void performRelu(const std::vector<std::vector<int>> &inputMatrix, std::vector<i
   std::vector<int> reluConst(numCols, 0);  
 
   std::vector<PimObjId> pimObjectList(numRows);
-  PimObjId obj1 = pimAlloc(PIM_ALLOC_AUTO, numCols, bitsPerElement, PIM_INT32);
+  PimObjId obj1 = pimAlloc(PIM_ALLOC_AUTO, numCols, PIM_INT32);
   if (obj1 == -1)
   {
     std::cout << "Function: " << __func__ << ", Abort: pimAlloc for PimObj obj1 failed" << std::endl;
@@ -536,7 +528,7 @@ void performRelu(const std::vector<std::vector<int>> &inputMatrix, std::vector<i
   pimObjectList[0] = obj1;
   for (int i = 1; i < numRows; i++)
   {
-    PimObjId obj = pimAllocAssociated(bitsPerElement, pimObjectList[0], PIM_INT32);
+    PimObjId obj = pimAllocAssociated(pimObjectList[0], PIM_INT32);
     if (obj == -1)
     {
       std::cout << "Function: " << __func__ << ", Abort: pimAllocAssociated for PimObj obj failed" << std::endl;
@@ -544,7 +536,7 @@ void performRelu(const std::vector<std::vector<int>> &inputMatrix, std::vector<i
     }
     pimObjectList[i] = obj;
   }
-  PimObjId RELUConstObj = pimAllocAssociated(bitsPerElement, pimObjectList[0], PIM_INT32);
+  PimObjId RELUConstObj = pimAllocAssociated(pimObjectList[0], PIM_INT32);
   if (RELUConstObj == -1)
   {
       std::cout << "Function: " << __func__ << ", Abort: pimAllocAssociated for PimObj RELUConstObj failed" << std::endl;

--- a/tests/bitsimd-perf/bitsimd-perf.cpp
+++ b/tests/bitsimd-perf/bitsimd-perf.cpp
@@ -23,17 +23,16 @@ bool createPimDevice()
 bool testMicroOps()
 {
   unsigned numElements = 3000;
-  unsigned bitsPerElement = 32;
 
   std::vector<int> src1(numElements);
   std::vector<int> src2(numElements);
   std::vector<int> dest(numElements);
 
-  PimObjId obj1 = pimAlloc(PIM_ALLOC_AUTO, numElements, bitsPerElement, PIM_INT32);
+  PimObjId obj1 = pimAlloc(PIM_ALLOC_AUTO, numElements, PIM_INT32);
   assert(obj1 != -1);
-  PimObjId obj2 = pimAllocAssociated(bitsPerElement, obj1, PIM_INT32);
+  PimObjId obj2 = pimAllocAssociated(obj1, PIM_INT32);
   assert(obj2 != -1);
-  PimObjId obj3 = pimAllocAssociated(bitsPerElement, obj1, PIM_INT32);
+  PimObjId obj3 = pimAllocAssociated(obj1, PIM_INT32);
   assert(obj3 != -1);
 
   // assign some initial values

--- a/tests/bitsimd-v-basic/bitsimd-v-basic.cpp
+++ b/tests/bitsimd-v-basic/bitsimd-v-basic.cpp
@@ -23,20 +23,19 @@ bool createPimDevice()
 bool testMicroOps()
 {
   unsigned numElements = 1000;
-  unsigned bitsPerElement = 32;
 
   std::vector<int> src1(numElements);
   std::vector<int> src2(numElements);
   std::vector<int> src3(numElements);
   std::vector<int> dest(numElements);
 
-  PimObjId obj1 = pimAlloc(PIM_ALLOC_V1, numElements, bitsPerElement, PIM_INT32);
+  PimObjId obj1 = pimAlloc(PIM_ALLOC_V1, numElements, PIM_INT32);
   assert(obj1 != -1);
-  PimObjId obj2 = pimAllocAssociated(bitsPerElement, obj1, PIM_INT32);
+  PimObjId obj2 = pimAllocAssociated(obj1, PIM_INT32);
   assert(obj2 != -1);
-  PimObjId obj3 = pimAllocAssociated(bitsPerElement, obj1, PIM_INT32);
+  PimObjId obj3 = pimAllocAssociated(obj1, PIM_INT32);
   assert(obj3 != -1);
-  PimObjId obj4 = pimAllocAssociated(bitsPerElement, obj1, PIM_INT32);
+  PimObjId obj4 = pimAllocAssociated(obj1, PIM_INT32);
   assert(obj4 != -1);
 
   // assign some initial values

--- a/tests/test-functional/test-i16.cpp
+++ b/tests/test-functional/test-i16.cpp
@@ -19,7 +19,6 @@ testFunctional::testI16()
   pimResetStats();
 
   unsigned numElements = 3000;
-  unsigned bitsPerElement = 16;
 
   std::vector<int16_t> src1(numElements);
   std::vector<int16_t> src2(numElements);
@@ -31,11 +30,11 @@ testFunctional::testI16()
     src2[i] = static_cast<int16_t>(i*2 + 9);
   }
 
-  PimObjId obj1 = pimAlloc(PIM_ALLOC_AUTO, numElements, bitsPerElement, PIM_INT16);
+  PimObjId obj1 = pimAlloc(PIM_ALLOC_AUTO, numElements, PIM_INT16);
   assert(obj1 != -1);
-  PimObjId obj2 = pimAllocAssociated(bitsPerElement, obj1, PIM_INT16);
+  PimObjId obj2 = pimAllocAssociated(obj1, PIM_INT16);
   assert(obj2 != -1);
-  PimObjId obj3 = pimAllocAssociated(bitsPerElement, obj1, PIM_INT16);
+  PimObjId obj3 = pimAllocAssociated(obj1, PIM_INT16);
   assert(obj3 != -1);
 
   PimStatus status = PIM_OK;

--- a/tests/test-functional/test-i32.cpp
+++ b/tests/test-functional/test-i32.cpp
@@ -19,7 +19,6 @@ testFunctional::testI32()
   pimResetStats();
 
   unsigned numElements = 3000;
-  unsigned bitsPerElement = 32;
 
   std::vector<int> src1(numElements);
   std::vector<int> src2(numElements);
@@ -31,11 +30,11 @@ testFunctional::testI32()
     src2[i] = i * 2 - 9;
   }
 
-  PimObjId obj1 = pimAlloc(PIM_ALLOC_AUTO, numElements, bitsPerElement, PIM_INT32);
+  PimObjId obj1 = pimAlloc(PIM_ALLOC_AUTO, numElements, PIM_INT32);
   assert(obj1 != -1);
-  PimObjId obj2 = pimAllocAssociated(bitsPerElement, obj1, PIM_INT32);
+  PimObjId obj2 = pimAllocAssociated(obj1, PIM_INT32);
   assert(obj2 != -1);
-  PimObjId obj3 = pimAllocAssociated(bitsPerElement, obj1, PIM_INT32);
+  PimObjId obj3 = pimAllocAssociated(obj1, PIM_INT32);
   assert(obj3 != -1);
 
   PimStatus status = PIM_OK;

--- a/tests/test-functional/test-i64.cpp
+++ b/tests/test-functional/test-i64.cpp
@@ -19,7 +19,6 @@ testFunctional::testI64()
   pimResetStats();
 
   unsigned numElements = 3000;
-  unsigned bitsPerElement = 64;
 
   std::vector<int64_t> src1(numElements);
   std::vector<int64_t> src2(numElements);
@@ -31,11 +30,11 @@ testFunctional::testI64()
     src2[i] = i * 2 + 2;
   }
 
-  PimObjId obj1 = pimAlloc(PIM_ALLOC_AUTO, numElements, bitsPerElement, PIM_INT64);
+  PimObjId obj1 = pimAlloc(PIM_ALLOC_AUTO, numElements, PIM_INT64);
   assert(obj1 != -1);
-  PimObjId obj2 = pimAllocAssociated(bitsPerElement, obj1, PIM_INT64);
+  PimObjId obj2 = pimAllocAssociated(obj1, PIM_INT64);
   assert(obj2 != -1);
-  PimObjId obj3 = pimAllocAssociated(bitsPerElement, obj1, PIM_INT64);
+  PimObjId obj3 = pimAllocAssociated(obj1, PIM_INT64);
   assert(obj3 != -1);
 
   PimStatus status = PIM_OK;

--- a/tests/test-functional/test-i8.cpp
+++ b/tests/test-functional/test-i8.cpp
@@ -19,7 +19,6 @@ testFunctional::testI8()
   pimResetStats();
 
   unsigned numElements = 3000;
-  unsigned bitsPerElement = 8;
 
   std::vector<int8_t> src1(numElements);
   std::vector<int8_t> src2(numElements);
@@ -31,11 +30,11 @@ testFunctional::testI8()
     src2[i] = static_cast<int8_t>(i*2 + 9);
   }
 
-  PimObjId obj1 = pimAlloc(PIM_ALLOC_AUTO, numElements, bitsPerElement, PIM_INT8);
+  PimObjId obj1 = pimAlloc(PIM_ALLOC_AUTO, numElements, PIM_INT8);
   assert(obj1 != -1);
-  PimObjId obj2 = pimAllocAssociated(bitsPerElement, obj1, PIM_INT8);
+  PimObjId obj2 = pimAllocAssociated(obj1, PIM_INT8);
   assert(obj2 != -1);
-  PimObjId obj3 = pimAllocAssociated(bitsPerElement, obj1, PIM_INT8);
+  PimObjId obj3 = pimAllocAssociated(obj1, PIM_INT8);
   assert(obj3 != -1);
 
   PimStatus status = PIM_OK;

--- a/tests/test-functional/test-u16.cpp
+++ b/tests/test-functional/test-u16.cpp
@@ -19,7 +19,6 @@ testFunctional::testU16()
   pimResetStats();
 
   unsigned numElements = 3000;
-  unsigned bitsPerElement = 16;
 
   std::vector<uint16_t> src1(numElements);
   std::vector<uint16_t> src2(numElements);
@@ -31,11 +30,11 @@ testFunctional::testU16()
     src2[i] = static_cast<uint16_t>(i*2 + 9);
   }
 
-  PimObjId obj1 = pimAlloc(PIM_ALLOC_AUTO, numElements, bitsPerElement, PIM_UINT16);
+  PimObjId obj1 = pimAlloc(PIM_ALLOC_AUTO, numElements, PIM_UINT16);
   assert(obj1 != -1);
-  PimObjId obj2 = pimAllocAssociated(bitsPerElement, obj1, PIM_UINT16);
+  PimObjId obj2 = pimAllocAssociated(obj1, PIM_UINT16);
   assert(obj2 != -1);
-  PimObjId obj3 = pimAllocAssociated(bitsPerElement, obj1, PIM_UINT16);
+  PimObjId obj3 = pimAllocAssociated(obj1, PIM_UINT16);
   assert(obj3 != -1);
 
   PimStatus status = PIM_OK;

--- a/tests/test-functional/test-u32.cpp
+++ b/tests/test-functional/test-u32.cpp
@@ -19,7 +19,6 @@ testFunctional::testU32()
   pimResetStats();
 
   unsigned numElements = 3000;
-  unsigned bitsPerElement = 32;
 
   std::vector<uint> src1(numElements);
   std::vector<uint> src2(numElements);
@@ -31,11 +30,11 @@ testFunctional::testU32()
     src2[i] = i * 2 - 9;
   }
 
-  PimObjId obj1 = pimAlloc(PIM_ALLOC_AUTO, numElements, bitsPerElement, PIM_UINT32);
+  PimObjId obj1 = pimAlloc(PIM_ALLOC_AUTO, numElements, PIM_UINT32);
   assert(obj1 != -1);
-  PimObjId obj2 = pimAllocAssociated(bitsPerElement, obj1, PIM_UINT32);
+  PimObjId obj2 = pimAllocAssociated(obj1, PIM_UINT32);
   assert(obj2 != -1);
-  PimObjId obj3 = pimAllocAssociated(bitsPerElement, obj1, PIM_UINT32);
+  PimObjId obj3 = pimAllocAssociated(obj1, PIM_UINT32);
   assert(obj3 != -1);
 
   PimStatus status = PIM_OK;

--- a/tests/test-functional/test-u64.cpp
+++ b/tests/test-functional/test-u64.cpp
@@ -19,7 +19,6 @@ testFunctional::testU64()
   pimResetStats();
 
   unsigned numElements = 3000;
-  unsigned bitsPerElement = 64;
 
   std::vector<uint64_t> src1(numElements);
   std::vector<uint64_t> src2(numElements);
@@ -31,11 +30,11 @@ testFunctional::testU64()
     src2[i] = i * 2 + 2;
   }
 
-  PimObjId obj1 = pimAlloc(PIM_ALLOC_AUTO, numElements, bitsPerElement, PIM_UINT64);
+  PimObjId obj1 = pimAlloc(PIM_ALLOC_AUTO, numElements, PIM_UINT64);
   assert(obj1 != -1);
-  PimObjId obj2 = pimAllocAssociated(bitsPerElement, obj1, PIM_UINT64);
+  PimObjId obj2 = pimAllocAssociated(obj1, PIM_UINT64);
   assert(obj2 != -1);
-  PimObjId obj3 = pimAllocAssociated(bitsPerElement, obj1, PIM_UINT64);
+  PimObjId obj3 = pimAllocAssociated(obj1, PIM_UINT64);
   assert(obj3 != -1);
 
   PimStatus status = PIM_OK;

--- a/tests/test-functional/test-u8.cpp
+++ b/tests/test-functional/test-u8.cpp
@@ -19,7 +19,6 @@ testFunctional::testU8()
   pimResetStats();
 
   unsigned numElements = 3000;
-  unsigned bitsPerElement = 8;
 
   std::vector<uint8_t> src1(numElements);
   std::vector<uint8_t> src2(numElements);
@@ -31,11 +30,11 @@ testFunctional::testU8()
     src2[i] = static_cast<uint8_t>(((i*2 + 9)%255)+1);
   }
 
-  PimObjId obj1 = pimAlloc(PIM_ALLOC_AUTO, numElements, bitsPerElement, PIM_UINT8);
+  PimObjId obj1 = pimAlloc(PIM_ALLOC_AUTO, numElements, PIM_UINT8);
   assert(obj1 != -1);
-  PimObjId obj2 = pimAllocAssociated(bitsPerElement, obj1, PIM_UINT8);
+  PimObjId obj2 = pimAllocAssociated(obj1, PIM_UINT8);
   assert(obj2 != -1);
-  PimObjId obj3 = pimAllocAssociated(bitsPerElement, obj1, PIM_UINT8);
+  PimObjId obj3 = pimAllocAssociated(obj1, PIM_UINT8);
   assert(obj3 != -1);
 
   PimStatus status = PIM_OK;

--- a/tests/test-large-copy-ranged/test-large-copy-ranged.cpp
+++ b/tests/test-large-copy-ranged/test-large-copy-ranged.cpp
@@ -24,7 +24,6 @@ void testLargeCopy(PimDeviceEnum deviceType)
 
   uint64_t numElements = 2LL * 1024 * 1024 + 2; // 4G + 2 elements
   uint64_t HostNumElements = numElements;  
-  unsigned bitsPerElement = 8;
   std::vector<char> src(HostNumElements);
   std::vector<char> dest(HostNumElements);
   for (uint64_t i = 0; i < HostNumElements; ++i) {
@@ -36,7 +35,7 @@ void testLargeCopy(PimDeviceEnum deviceType)
 
   // test a few iterations
   for (int iter = 0; iter < 2; ++iter) {
-    PimObjId obj = pimAlloc(PIM_ALLOC_AUTO, numElements, bitsPerElement, PIM_INT8);
+    PimObjId obj = pimAlloc(PIM_ALLOC_AUTO, numElements, PIM_INT8);
     assert(obj != -1);
 
     status = pimCopyHostToDevice((void*)src.data(), obj, 0, HostNumElements);

--- a/tests/test-large-copy/test-large-copy.cpp
+++ b/tests/test-large-copy/test-large-copy.cpp
@@ -23,7 +23,6 @@ void testLargeCopy(PimDeviceEnum deviceType)
   unsigned numCols = 8192;
 
   uint64_t numElements = 4LL * 1024 * 1024 * 1024 + 2; // 4G + 2 elements
-  unsigned bitsPerElement = 8;
   std::vector<char> src(numElements);
   std::vector<char> dest(numElements);
   for (uint64_t i = 0; i < numElements; ++i) {
@@ -35,7 +34,7 @@ void testLargeCopy(PimDeviceEnum deviceType)
 
   // test a few iterations
   for (int iter = 0; iter < 2; ++iter) {
-    PimObjId obj = pimAlloc(PIM_ALLOC_AUTO, numElements, bitsPerElement, PIM_INT8);
+    PimObjId obj = pimAlloc(PIM_ALLOC_AUTO, numElements, PIM_INT8);
     assert(obj != -1);
 
     status = pimCopyHostToDevice((void*)src.data(), obj);

--- a/tests/test-redsum/test-redsum.cpp
+++ b/tests/test-redsum/test-redsum.cpp
@@ -23,7 +23,6 @@ void testRedSum(PimDeviceEnum deviceType)
   unsigned numCols = 1024;
 
   uint64_t numElements = 65536;
-  unsigned bitsPerElement = 32;
   std::vector<unsigned> src(numElements);
   std::vector<unsigned> dest(numElements);
   unsigned sum32 = 0;
@@ -47,7 +46,7 @@ void testRedSum(PimDeviceEnum deviceType)
 
   // test a few iterations
   for (int iter = 0; iter < 2; ++iter) {
-    PimObjId obj = pimAlloc(PIM_ALLOC_AUTO, numElements, bitsPerElement, PIM_UINT32);
+    PimObjId obj = pimAlloc(PIM_ALLOC_AUTO, numElements, PIM_UINT32);
     assert(obj != -1);
 
     status = pimCopyHostToDevice((void*)src.data(), obj);

--- a/tests/test-simdram/test-simdram.cpp
+++ b/tests/test-simdram/test-simdram.cpp
@@ -23,7 +23,6 @@ bool createPimDevice()
 bool testMicroOps()
 {
   unsigned numElements = 1000;
-  unsigned bitsPerElement = 32;
 
   std::vector<int> src1(numElements);
   std::vector<int> src2(numElements);
@@ -34,9 +33,9 @@ bool testMicroOps()
     src2[i] = static_cast<int>(i * 3 + 1);
   }
 
-  PimObjId obj1 = pimAlloc(PIM_ALLOC_V1, numElements, bitsPerElement, PIM_INT32);
+  PimObjId obj1 = pimAlloc(PIM_ALLOC_V1, numElements, PIM_INT32);
   assert(obj1 != -1);
-  PimObjId obj2 = pimAllocAssociated(bitsPerElement, obj1, PIM_INT32);
+  PimObjId obj2 = pimAllocAssociated(obj1, PIM_INT32);
   assert(obj2 != -1);
   PimObjId obj3 = pimCreateDualContactRef(obj2);
   assert(obj3 != -1);


### PR DESCRIPTION
PR #165 combines multiple changes to dev-alloc branch, which is hard to review. I would suggest we merge this batch of changes to main first for API updates that touch all benchmark apps. 

List of changes:
- Remove bitsPerElement parameter from pimAlloc and pimAllocAssociated. Auto derive bitsPerElement from data type by calling newly added pimUtils::getNumBitsOfDataType. Currently all bitsPerElement parameters match with given data type exactly, so they can be safely removed.
- Add misc-bench folder to top-level Makefile. Currently it is not compiled.
- Fix a bug in scale (incorrect associated obj) and print warnings in bitmap and xor.
