### PR TITLE
Update fp precision in pimParams.

### DIFF
--- a/libpimeval/src/pimParamsDDRDram.h
+++ b/libpimeval/src/pimParamsDDRDram.h
@@ -23,11 +23,11 @@ public:
   int getDeviceWidth() const override { return m_deviceWidth;}
   int getBurstLength() const override { return m_BL;}
   int getNumChipsPerRank() const override {return m_busWidth / m_deviceWidth; }
-  float getNsRowRead() const override { return m_tCK * (m_tRCD + m_tRP); }
-  float getNsRowWrite() const override { return m_tCK * (m_tWR + m_tRP + m_tRCD); }
-  float getNsTCCD_S() const override { return m_tCK * m_tCCD_S; }
-  float getNsTCAS() const override { return m_tCK * m_CL; }
-  float getNsAAP() const override { return m_tCK * (m_tRAS + m_tRP); }
+  double getNsRowRead() const override { return m_tCK * (m_tRCD + m_tRP); }
+  double getNsRowWrite() const override { return m_tCK * (m_tWR + m_tRP + m_tRCD); }
+  double getNsTCCD_S() const override { return m_tCK * m_tCCD_S; }
+  double getNsTCAS() const override { return m_tCK * m_CL; }
+  double getNsAAP() const override { return m_tCK * (m_tRAS + m_tRP); }
   double getTypicalRankBW() const override { return m_typicalRankBW; }
   double getPjRowRead() const override { return m_VDD * (m_IDD0 * (m_tRAS + m_tRP) - (m_IDD3N * m_tRAS + m_IDD2N * m_tRP)); } // Energy for 1 Activate command (and the correspound precharge command) in one subarray of one bank of one chip
   double getPjLogic() const override { return 0.007 * m_tCK * m_tCCD_S ; } // 0.007 mW is the total power per BSLU, 0.007 * m_tCK * m_tCCD_S is the energy of one BSLU during one logic operation in pJ.
@@ -47,7 +47,7 @@ private:
   int m_BL = 0;
 
   // [timing]
-  float m_tCK = 0.0;
+  double m_tCK = 0.0;
   int m_AL = 0;
   int m_CL = 0;
   int m_CWL = 0;
@@ -77,9 +77,9 @@ private:
   int m_tRTRS = 0;
 
   // [power]
-  float m_VDD = 0.0;
+  double m_VDD = 0.0;
   int m_IDD0 = 0;
-  float m_IPP0 = 0;
+  double m_IPP0 = 0;
   int m_IDD2P = 0;
   int m_IDD2N = 0;
   int m_IDD3P = 0;

--- a/libpimeval/src/pimParamsDram.h
+++ b/libpimeval/src/pimParamsDram.h
@@ -29,11 +29,11 @@ public:
   virtual int getDeviceWidth() const = 0;
   virtual int getBurstLength() const = 0;
   virtual int getNumChipsPerRank() const = 0;
-  virtual float getNsRowRead() const = 0;
-  virtual float getNsRowWrite() const = 0;
-  virtual float getNsTCCD_S() const = 0;
-  virtual float getNsTCAS() const = 0;
-  virtual float getNsAAP() const = 0;
+  virtual double getNsRowRead() const = 0;
+  virtual double getNsRowWrite() const = 0;
+  virtual double getNsTCCD_S() const = 0;
+  virtual double getNsTCAS() const = 0;
+  virtual double getNsAAP() const = 0;
   virtual double getTypicalRankBW() const = 0;
   virtual double getPjRowRead() const = 0;
   virtual double getPjLogic() const = 0;

--- a/libpimeval/src/pimParamsLPDDRDram.h
+++ b/libpimeval/src/pimParamsLPDDRDram.h
@@ -23,11 +23,11 @@ public:
   int getDeviceWidth() const override { return m_deviceWidth;}
   int getBurstLength() const override { return m_BL;}
   int getNumChipsPerRank() const override {return m_busWidth / m_deviceWidth; }
-  float getNsRowRead() const override { return m_tCK * (m_tRCD + m_tRP); }
-  float getNsRowWrite() const override { return m_tCK * (m_tWR + m_tRP + m_tRCD); }
-  float getNsTCCD_S() const override { return m_tCK * m_tCCD_S; }
-  float getNsTCAS() const override { return m_tCK * m_CL; }
-  float getNsAAP() const override { return m_tCK * (m_tRAS + m_tRP); }
+  double getNsRowRead() const override { return m_tCK * (m_tRCD + m_tRP); }
+  double getNsRowWrite() const override { return m_tCK * (m_tWR + m_tRP + m_tRCD); }
+  double getNsTCCD_S() const override { return m_tCK * m_tCCD_S; }
+  double getNsTCAS() const override { return m_tCK * m_CL; }
+  double getNsAAP() const override { return m_tCK * (m_tRAS + m_tRP); }
   double getTypicalRankBW() const override { return m_typicalRankBW; }
   double getPjRowRead() const override { return m_VDD * (m_IDD0 * (m_tRAS + m_tRP) - (m_IDD3N * m_tRAS + m_IDD2N * m_tRP)); } // Energy for 1 Activate command (and the correspound precharge command) in one subarray of one bank of one chip
   double getPjLogic() const override { return 0.007 * m_tCK * m_tCCD_S ; } // 0.007 mW is the total power per BSLU, 0.007 * m_tCK * m_tCCD_S is the energy of one BSLU during one logic operation in pJ.
@@ -47,7 +47,7 @@ private:
   int m_BL = 0;
 
   // [timing]
-  float m_tCK = 0.0;
+  double m_tCK = 0.0;
   int m_AL = 0;
   int m_CL = 0;
   int m_CWL = 0;
@@ -78,9 +78,9 @@ private:
   int m_tPPD = 0;
 
   // [power]
-  float m_VDD = 0.0;
+  double m_VDD = 0.0;
   int m_IDD0 = 0;
-  float m_IPP0 = 0;
+  double m_IPP0 = 0;
   int m_IDD2P = 0;
   int m_IDD2N = 0;
   int m_IDD3P = 0;

--- a/tests/test-functional/result-golden.txt
+++ b/tests/test-functional/result-golden.txt
@@ -1842,26 +1842,26 @@ Data Copy Stats:
 PIM Command Stats:
                                       PIM-CMD :        CNT EstimatedRuntime(ms) EstimatedEnergyConsumption(mJ)
                                    abs.int8.h :          1       0.002629       0.004276
-                                   add.int8.h :          1       0.029312       0.022244
+                                   add.int8.h :          1       0.029313       0.022244
                             add_scaler.int8.h :          1       0.002629       0.004276
-                                   and.int8.h :          1       0.029312       0.022244
+                                   and.int8.h :          1       0.029313       0.022244
                             and_scaler.int8.h :          1       0.002629       0.004276
                              broadcast.int8.h :          2       0.005086       0.005809
-                                   div.int8.h :          1       0.029312       0.022244
+                                   div.int8.h :          1       0.029313       0.022244
                             div_scaler.int8.h :          1       0.002629       0.004276
-                                    eq.int8.h :          1       0.029312       0.022244
+                                    eq.int8.h :          1       0.029313       0.022244
                              eq_scaler.int8.h :          1       0.002629       0.004276
-                                    gt.int8.h :          1       0.029312       0.022244
+                                    gt.int8.h :          1       0.029313       0.022244
                              gt_scaler.int8.h :          1       0.002629       0.004276
-                                    lt.int8.h :          1       0.029312       0.022244
+                                    lt.int8.h :          1       0.029313       0.022244
                              lt_scaler.int8.h :          1       0.002629       0.004276
-                                   max.int8.h :          1       0.029312       0.022244
+                                   max.int8.h :          1       0.029313       0.022244
                             max_scaler.int8.h :          1       0.002629       0.004276
-                                   min.int8.h :          1       0.029312       0.022244
+                                   min.int8.h :          1       0.029313       0.022244
                             min_scaler.int8.h :          1       0.002629       0.004276
-                                   mul.int8.h :          1       0.029312       0.022244
+                                   mul.int8.h :          1       0.029313       0.022244
                             mul_scaler.int8.h :          1       0.002629       0.004276
-                                    or.int8.h :          1       0.029312       0.022244
+                                    or.int8.h :          1       0.029313       0.022244
                              or_scaler.int8.h :          1       0.002629       0.004276
                               popcount.int8.h :          1       0.002629       0.004276
                                 redsum.int8.h :          2       0.005086       0.005935
@@ -1873,11 +1873,11 @@ PIM Command Stats:
                           shift_bits_r.int8.h :          1       0.002629       0.004276
                           shift_elem_l.int8.h :          1       0.012759       0.000043
                           shift_elem_r.int8.h :          1       0.012759       0.000043
-                                   sub.int8.h :          1       0.029312       0.022244
+                                   sub.int8.h :          1       0.029313       0.022244
                             sub_scaler.int8.h :          1       0.002629       0.004276
-                                  xnor.int8.h :          1       0.029312       0.022244
+                                  xnor.int8.h :          1       0.029313       0.022244
                            xnor_scaler.int8.h :          1       0.002629       0.004276
-                                   xor.int8.h :          1       0.029312       0.022244
+                                   xor.int8.h :          1       0.029313       0.022244
                             xor_scaler.int8.h :          1       0.002629       0.004276
                               TOTAL --------- :         41       0.508001       0.392762
 ----------------------------------------
@@ -1945,26 +1945,26 @@ Data Copy Stats:
 PIM Command Stats:
                                       PIM-CMD :        CNT EstimatedRuntime(ms) EstimatedEnergyConsumption(mJ)
                                   abs.uint8.h :          1       0.002629       0.004276
-                                  add.uint8.h :          1       0.029312       0.022244
+                                  add.uint8.h :          1       0.029313       0.022244
                            add_scaler.uint8.h :          1       0.002629       0.004276
-                                  and.uint8.h :          1       0.029312       0.022244
+                                  and.uint8.h :          1       0.029313       0.022244
                            and_scaler.uint8.h :          1       0.002629       0.004276
                             broadcast.uint8.h :          2       0.005086       0.005809
-                                  div.uint8.h :          1       0.029312       0.022244
+                                  div.uint8.h :          1       0.029313       0.022244
                            div_scaler.uint8.h :          1       0.002629       0.004276
-                                   eq.uint8.h :          1       0.029312       0.022244
+                                   eq.uint8.h :          1       0.029313       0.022244
                             eq_scaler.uint8.h :          1       0.002629       0.004276
-                                   gt.uint8.h :          1       0.029312       0.022244
+                                   gt.uint8.h :          1       0.029313       0.022244
                             gt_scaler.uint8.h :          1       0.002629       0.004276
-                                   lt.uint8.h :          1       0.029312       0.022244
+                                   lt.uint8.h :          1       0.029313       0.022244
                             lt_scaler.uint8.h :          1       0.002629       0.004276
-                                  max.uint8.h :          1       0.029312       0.022244
+                                  max.uint8.h :          1       0.029313       0.022244
                            max_scaler.uint8.h :          1       0.002629       0.004276
-                                  min.uint8.h :          1       0.029312       0.022244
+                                  min.uint8.h :          1       0.029313       0.022244
                            min_scaler.uint8.h :          1       0.002629       0.004276
-                                  mul.uint8.h :          1       0.029312       0.022244
+                                  mul.uint8.h :          1       0.029313       0.022244
                            mul_scaler.uint8.h :          1       0.002629       0.004276
-                                   or.uint8.h :          1       0.029312       0.022244
+                                   or.uint8.h :          1       0.029313       0.022244
                             or_scaler.uint8.h :          1       0.002629       0.004276
                              popcount.uint8.h :          1       0.002629       0.004276
                                redsum.uint8.h :          2       0.005086       0.005935
@@ -1976,11 +1976,11 @@ PIM Command Stats:
                          shift_bits_r.uint8.h :          1       0.002629       0.004276
                          shift_elem_l.uint8.h :          1       0.012759       0.000043
                          shift_elem_r.uint8.h :          1       0.012759       0.000043
-                                  sub.uint8.h :          1       0.029312       0.022244
+                                  sub.uint8.h :          1       0.029313       0.022244
                            sub_scaler.uint8.h :          1       0.002629       0.004276
-                                 xnor.uint8.h :          1       0.029312       0.022244
+                                 xnor.uint8.h :          1       0.029313       0.022244
                           xnor_scaler.uint8.h :          1       0.002629       0.004276
-                                  xor.uint8.h :          1       0.029312       0.022244
+                                  xor.uint8.h :          1       0.029313       0.022244
                            xor_scaler.uint8.h :          1       0.002629       0.004276
                               TOTAL --------- :         41       0.508001       0.392762
 ----------------------------------------


### PR DESCRIPTION
Confirmed that the result differences are due to subtle FP type conversion behavior changes from inline functions to virtual APIs. Re-goldened results.