### PR TITLE
Decouple PIM object data and simulated memory for functional simulation memory and runtime

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -25,7 +25,7 @@ ifeq ($(MAKECMDGOALS),debug)
 	CXXFLAGS += -g -DDEBUG
 endif
 ifeq ($(MAKECMDGOALS),perf)
-	CXXFLAGS += -Ofast
+	CXXFLAGS += -Ofast -Wno-unknown-pragmas
 endif
 ifeq ($(MAKECMDGOALS),dramsim3_integ)
 	CXXFLAGS += -Ofast -DDRAMSIM3_INTEG

--- a/libpimeval/src/pimCmd.cpp
+++ b/libpimeval/src/pimCmd.cpp
@@ -9,6 +9,7 @@
 #include "pimDevice.h"
 #include "pimCore.h"
 #include "pimResMgr.h"
+#include "libpimeval.h"
 #include <cstdio>
 #include <cmath>
 #include <unordered_map>
@@ -161,20 +162,34 @@ pimCmdCopy::execute()
     return false;
   }
 
+  // for non-functional simulation, sync src data from simulated memory
+  if (pimSim::get()->getDeviceType() != PIM_FUNCTIONAL) {
+    if (m_cmdType == PimCmdEnum::COPY_D2H || m_cmdType == PimCmdEnum::COPY_D2D) {
+      pimObjInfo &objSrc = m_device->getResMgr()->getObjInfo(m_src);
+      objSrc.syncFromSimulatedMem(m_device);
+    }
+  }
+
   if (m_cmdType == PimCmdEnum::COPY_H2D) {
-    const pimObjInfo &objDest = m_device->getResMgr()->getObjInfo(m_dest);
-    unsigned numRegions = objDest.getRegions().size();
-    computeAllRegions(numRegions);
+    pimObjInfo &objDest = m_device->getResMgr()->getObjInfo(m_dest);
+    objDest.data().copyFromHost(m_ptr, m_idxBegin, m_idxEnd);
   } else if (m_cmdType == PimCmdEnum::COPY_D2H) {
     const pimObjInfo &objSrc = m_device->getResMgr()->getObjInfo(m_src);
-    unsigned numRegions = objSrc.getRegions().size();
-    computeAllRegions(numRegions);
+    objSrc.data().copyToHost(m_ptr, m_idxBegin, m_idxEnd);
   } else if (m_cmdType == PimCmdEnum::COPY_D2D) {
     const pimObjInfo &objSrc = m_device->getResMgr()->getObjInfo(m_src);
-    unsigned numRegions = objSrc.getRegions().size();
-    computeAllRegions(numRegions);
+    pimObjInfo &objDest = m_device->getResMgr()->getObjInfo(m_dest);
+    objSrc.data().copyToObj(objDest.data(), m_idxBegin, m_idxEnd);
   } else {
     assert(0);
+  }
+
+  // for non-functional simulation, sync dest data to simulated memory
+  if (pimSim::get()->getDeviceType() != PIM_FUNCTIONAL) {
+    if (m_cmdType == PimCmdEnum::COPY_H2D || m_cmdType == PimCmdEnum::COPY_D2D) {
+      const pimObjInfo &objDest = m_device->getResMgr()->getObjInfo(m_dest);
+      objDest.syncToSimulatedMem(m_device);
+    }
   }
 
   updateStats();
@@ -256,144 +271,6 @@ pimCmdCopy::sanityCheck() const
   return true;
 }
 
-//! @brief  PIM Data Copy - compute region
-bool
-pimCmdCopy::computeRegion(unsigned index)
-{
-  // read in bits from src (host or PIM)
-  std::vector<bool> bits;
-  if (m_cmdType == PimCmdEnum::COPY_H2D) {
-    const pimObjInfo &objDest = m_device->getResMgr()->getObjInfo(m_dest);
-    const pimRegion& region = objDest.getRegions()[index];
-    unsigned numAllocRows = region.getNumAllocRows();
-    unsigned numAllocCols = region.getNumAllocCols();
-    unsigned bitsPerElement = objDest.getBitsPerElement();
-    unsigned numElementInCurRegion = numAllocRows * numAllocCols / bitsPerElement;
-    uint64_t byteOfst = (uint64_t)index * objDest.getMaxElementsPerRegion() * bitsPerElement / 8;
-    void* ptr = (void*)((char*)m_ptr + byteOfst);
-    bits = pimUtils::readBitsFromHost(ptr, numElementInCurRegion, bitsPerElement);
-  } else if (m_cmdType == PimCmdEnum::COPY_D2H || m_cmdType == PimCmdEnum::COPY_D2D) {
-    const pimObjInfo &objSrc = m_device->getResMgr()->getObjInfo(m_src);
-    const pimRegion& region = objSrc.getRegions()[index];
-    unsigned rowIdx = region.getRowIdx();
-    unsigned colIdx = region.getColIdx();
-    unsigned numAllocRows = region.getNumAllocRows();
-    unsigned numAllocCols = region.getNumAllocCols();
-    unsigned bitsPerElement = objSrc.getBitsPerElement();
-    PimCoreId coreId = region.getCoreId();
-    pimCore& core = m_device->getCore(coreId);
-    bool isDCCN = objSrc.isDualContactRef();
-    uint64_t reginBeginIdx = (uint64_t)objSrc.getMaxElementsPerRegion() * index; 
-    if (m_copyType == PIM_COPY_V) {
-      for (unsigned c = 0; c < numAllocCols; ++c) {
-        for (unsigned r = 0; r < numAllocRows; ++r) {
-          unsigned row = rowIdx + r;
-          unsigned col = colIdx + c;
-          bool val = core.getBit(row, col);
-          if (isDCCN) { val = !val; }
-          if (!m_copyFullRange) {
-            uint64_t currIdx = reginBeginIdx + c; 
-            if (currIdx >= m_idxBegin && currIdx < m_idxEnd) {
-              bits.push_back(val);
-            }
-          }
-          else {
-            bits.push_back(val);
-          }
-        }
-      }
-    } else if (m_copyType == PIM_COPY_H) {
-      for (unsigned r = 0; r < numAllocRows; ++r) {
-        for (unsigned c = 0; c < numAllocCols; ++c) {
-          unsigned row = rowIdx + r;
-          unsigned col = colIdx + c;
-          bool val = core.getBit(row, col);
-          if (isDCCN) { val = !val; }
-          if (!m_copyFullRange) {
-            uint64_t currIdx = reginBeginIdx + c / bitsPerElement; 
-            if (currIdx >= m_idxBegin && currIdx < m_idxEnd) {
-              bits.push_back(val);
-            }
-          }
-          else {
-            bits.push_back(val);
-          }
-        }
-      }
-    } else {
-      assert(0);
-    }
-  } else {
-    assert(0);
-  }
-
-  // write bits to dest (host or PIM)
-  if (m_cmdType == PimCmdEnum::COPY_H2D || m_cmdType == PimCmdEnum::COPY_D2D) {
-    const pimObjInfo &objDest = m_device->getResMgr()->getObjInfo(m_dest);
-    const pimRegion& region = objDest.getRegions()[index];
-    unsigned rowIdx = region.getRowIdx();
-    unsigned colIdx = region.getColIdx();
-    unsigned numAllocRows = region.getNumAllocRows();
-    unsigned numAllocCols = region.getNumAllocCols();
-    unsigned bitsPerElement = objDest.getBitsPerElement();
-    PimCoreId coreId = region.getCoreId();
-    pimCore& core = m_device->getCore(coreId);
-    bool isDCCN = objDest.isDualContactRef();
-    uint64_t regionBeginIdx = (uint64_t)objDest.getMaxElementsPerRegion() * index;
-    if (m_copyType == PIM_COPY_V) {
-      size_t bitIdx = 0;
-      for (size_t i = 0; i < (size_t)numAllocRows * numAllocCols; ++i) {
-        unsigned row = rowIdx + i % numAllocRows;
-        unsigned col = colIdx + i / numAllocRows;
-        if (!m_copyFullRange) {
-          uint64_t currIdx = regionBeginIdx + col;
-          if (currIdx >= m_idxBegin && currIdx < m_idxEnd) {
-            bool val = bits[bitIdx++];
-            if (isDCCN) { val = !val; }
-            core.setBit(row, col, val);
-          }
-        } 
-        else {
-          bool val = bits[bitIdx++];
-          if (isDCCN) { val = !val; }
-          core.setBit(row, col, val);
-        }
-      }
-    } else if (m_copyType == PIM_COPY_H) {
-      size_t bitIdx = 0;
-      for (size_t i = 0; i < (size_t)numAllocRows * numAllocCols; ++i) {
-        unsigned row = rowIdx + i / numAllocCols;
-        unsigned col = colIdx + i % numAllocCols;
-        if (!m_copyFullRange) {
-          uint64_t currIdx = regionBeginIdx + col / bitsPerElement;
-          if (currIdx >= m_idxBegin && currIdx < m_idxEnd) {
-            bool val = bits[bitIdx++];
-            if (isDCCN) { val = !val; }
-            core.setBit(row, col, val);
-          }
-        } 
-        else {
-          bool val = bits[bitIdx++];
-          if (isDCCN) { val = !val; }
-          core.setBit(row, col, val);
-        }
-      }
-    } else {
-      assert(0);
-    }
-  } else if (m_cmdType == PimCmdEnum::COPY_D2H) {
-    const pimObjInfo &objSrc = m_device->getResMgr()->getObjInfo(m_src);
-    unsigned bitsPerElement = objSrc.getBitsPerElement();
-    uint64_t byteOfst = (uint64_t)index * objSrc.getMaxElementsPerRegion() * bitsPerElement / 8;
-    void* ptr = (void*)((char*)m_ptr + byteOfst);
-    pimUtils::writeBitsToHost(ptr, bits);
-  } else {
-    assert(0);
-  }
-
-  return true;
-}
-
 //! @brief  PIM Data Copy - update stats
 bool
 pimCmdCopy::updateStats() const
@@ -462,9 +339,19 @@ pimCmdFunc1::execute()
     return false;
   }
 
+  if (pimSim::get()->getDeviceType() != PIM_FUNCTIONAL) {
+    pimObjInfo &objSrc = m_device->getResMgr()->getObjInfo(m_src);
+    objSrc.syncFromSimulatedMem(m_device);
+  }
+
   const pimObjInfo& objSrc = m_device->getResMgr()->getObjInfo(m_src);
   unsigned numRegions = objSrc.getRegions().size();
   computeAllRegions(numRegions);
+
+  if (pimSim::get()->getDeviceType() != PIM_FUNCTIONAL) {
+    const pimObjInfo &objDest = m_device->getResMgr()->getObjInfo(m_dest);
+    objDest.syncToSimulatedMem(m_device);
+  }
 
   updateStats();
   return true;
@@ -491,36 +378,28 @@ bool
 pimCmdFunc1::computeRegion(unsigned index)
 {
   const pimObjInfo& objSrc = m_device->getResMgr()->getObjInfo(m_src);
-  const pimObjInfo& objDest = m_device->getResMgr()->getObjInfo(m_dest);
+  pimObjInfo& objDest = m_device->getResMgr()->getObjInfo(m_dest);
+
   PimDataType dataType = objSrc.getDataType();
-  bool isVLayout = objSrc.isVLayout();
   unsigned bitsPerElementSrc = objSrc.getBitsPerElement();
-  unsigned bitsPerElementDest = objDest.getBitsPerElement();
-
   const pimRegion& srcRegion = objSrc.getRegions()[index];
-  const pimRegion& destRegion = objDest.getRegions()[index];
 
-  PimCoreId coreId = srcRegion.getCoreId();
-  pimCore& core = m_device->getCore(coreId);
-
-  // perform the computation
+  uint64_t elemIdxBegin = srcRegion.getElemIdxBegin();
   unsigned numElementsInRegion = srcRegion.getNumElemInRegion();
   for (unsigned j = 0; j < numElementsInRegion; ++j) {
+    uint64_t elemIdx = elemIdxBegin + j;
     if (dataType == PIM_INT8 || dataType == PIM_INT16 || dataType == PIM_INT32 || dataType == PIM_INT64 || dataType == PIM_UINT8 || dataType == PIM_UINT16 || dataType == PIM_UINT32 || dataType == PIM_UINT64) {
-      auto locSrc = srcRegion.locateIthElemInRegion(j);
-      auto locDest = destRegion.locateIthElemInRegion(j);
-      uint64_t operandBits = getBits(core, isVLayout, locSrc.first, locSrc.second, bitsPerElementSrc);
       bool isSigned = (dataType == PIM_INT8 || dataType == PIM_INT16 || dataType == PIM_INT32 || dataType == PIM_INT64);
       if (isSigned) {
-        int64_t signedOperand = pimUtils::signExt(operandBits, dataType);
+        int64_t signedOperand = objSrc.data().getElementBits(elemIdx);
         int64_t result = 0;
         if(!computeResult(signedOperand, m_cmdType, (int64_t)m_scalarValue, result, bitsPerElementSrc)) return false;
-        setBits(core, isVLayout, locDest.first, locDest.second, pimUtils::castTypeToBits(result), bitsPerElementDest);
+        objDest.data().setElement(elemIdx, result);
       } else {
-        uint64_t unsignedOperand = operandBits;
+        uint64_t unsignedOperand = objSrc.data().getElementBits(elemIdx);
         uint64_t result = 0;
         if(!computeResult(unsignedOperand, m_cmdType, m_scalarValue, result, bitsPerElementSrc)) return false;
-        setBits(core, isVLayout, locDest.first, locDest.second, result, bitsPerElementDest);
+        objDest.data().setElement(elemIdx, result);
       }
     } else {
       assert(0); // todo: data type
@@ -555,9 +434,21 @@ pimCmdFunc2::execute()
     return false;
   }
 
+  if (pimSim::get()->getDeviceType() != PIM_FUNCTIONAL) {
+    pimObjInfo &objSrc1 = m_device->getResMgr()->getObjInfo(m_src1);
+    pimObjInfo &objSrc2 = m_device->getResMgr()->getObjInfo(m_src2);
+    objSrc1.syncFromSimulatedMem(m_device);
+    objSrc2.syncFromSimulatedMem(m_device);
+  }
+
   const pimObjInfo& objSrc1 = m_device->getResMgr()->getObjInfo(m_src1);
   unsigned numRegions = objSrc1.getRegions().size();
   computeAllRegions(numRegions);
+
+  if (pimSim::get()->getDeviceType() != PIM_FUNCTIONAL) {
+    const pimObjInfo &objDest = m_device->getResMgr()->getObjInfo(m_dest);
+    objDest.syncToSimulatedMem(m_device);
+  }
 
   updateStats();
   return true;
@@ -586,31 +477,21 @@ pimCmdFunc2::computeRegion(unsigned index)
 {
   const pimObjInfo& objSrc1 = m_device->getResMgr()->getObjInfo(m_src1);
   const pimObjInfo& objSrc2 = m_device->getResMgr()->getObjInfo(m_src2);
-  const pimObjInfo& objDest = m_device->getResMgr()->getObjInfo(m_dest);
+  pimObjInfo& objDest = m_device->getResMgr()->getObjInfo(m_dest);
 
   PimDataType dataType = objSrc1.getDataType();
-  bool isVLayout = objSrc1.isVLayout();
-  unsigned bitsPerElementSrc1 = objSrc1.getBitsPerElement();
-  unsigned bitsPerElementSrc2 = objSrc2.getBitsPerElement();
-  unsigned bitsPerElementdest = objDest.getBitsPerElement();
 
   const pimRegion& src1Region = objSrc1.getRegions()[index];
-  const pimRegion& src2Region = objSrc2.getRegions()[index];
-  const pimRegion& destRegion = objDest.getRegions()[index];
-
-  PimCoreId coreId = src1Region.getCoreId();
-  pimCore& core = m_device->getCore(coreId);
 
   // perform the computation
+  uint64_t elemIdxBegin = src1Region.getElemIdxBegin();
   unsigned numElementsInRegion = src1Region.getNumElemInRegion();
   for (unsigned j = 0; j < numElementsInRegion; ++j) {
-    auto locSrc1 = src1Region.locateIthElemInRegion(j);
-    auto locSrc2 = src2Region.locateIthElemInRegion(j);
-    auto locDest = destRegion.locateIthElemInRegion(j);
+    uint64_t elemIdx = elemIdxBegin + j;
 
     if (dataType == PIM_INT8 || dataType == PIM_INT16 || dataType == PIM_INT32 || dataType == PIM_INT64 || dataType == PIM_UINT8 || dataType == PIM_UINT16 || dataType == PIM_UINT32 || dataType == PIM_UINT64) {
-      uint64_t operandBits1 = getBits(core, isVLayout, locSrc1.first, locSrc1.second, bitsPerElementSrc1);
-      uint64_t operandBits2 = getBits(core, isVLayout, locSrc2.first, locSrc2.second, bitsPerElementSrc2);
+      uint64_t operandBits1 = objSrc1.data().getElementBits(elemIdx);
+      uint64_t operandBits2 = objSrc2.data().getElementBits(elemIdx);
       // The following if-else block is the perfect example of where a Template would have been much more cleaner and efficient and less error prone
       if (dataType == PIM_INT8 || dataType == PIM_INT16 || dataType == PIM_INT32 || dataType == PIM_INT64) {
         int64_t operand1 = pimUtils::signExt(operandBits1, dataType);
@@ -641,7 +522,7 @@ pimCmdFunc2::computeRegion(unsigned index)
           std::printf("PIM-Error: Unexpected cmd type %d\n", m_cmdType);
           assert(0);
         }
-        setBits(core, isVLayout, locDest.first, locDest.second, pimUtils::castTypeToBits(result), bitsPerElementdest);
+        objDest.data().setElement(elemIdx, result);
       } else {
         uint64_t operand1 = operandBits1;
         uint64_t operand2 = operandBits2;
@@ -671,11 +552,11 @@ pimCmdFunc2::computeRegion(unsigned index)
           std::printf("PIM-Error: Unexpected cmd type %d\n", m_cmdType);
           assert(0);
         }
-        setBits(core, isVLayout, locDest.first, locDest.second, result, bitsPerElementdest);
+        objDest.data().setElement(elemIdx, result);
       }
     } else if (dataType == PIM_FP32) {
-      uint64_t operandBits1 = getBits(core, isVLayout, locSrc1.first, locSrc1.second, bitsPerElementSrc1);
-      uint64_t operandBits2 = getBits(core, isVLayout, locSrc2.first, locSrc2.second, bitsPerElementSrc2);
+      uint64_t operandBits1 = objSrc1.data().getElementBits(elemIdx);
+      uint64_t operandBits2 = objSrc2.data().getElementBits(elemIdx);
       float operand1 = pimUtils::castBitsToType<float>(operandBits1);
       float operand2 = pimUtils::castBitsToType<float>(operandBits2);
       float result = 0;
@@ -694,7 +575,7 @@ pimCmdFunc2::computeRegion(unsigned index)
         std::printf("PIM-Error: Unsupported FP32 cmd type %d\n", static_cast<int>(m_cmdType));
         assert(0);
       }
-      setBits(core, isVLayout, locDest.first, locDest.second, pimUtils::castTypeToBits(result), bitsPerElementdest);
+      objDest.data().setElement(elemIdx, result);
     } else {
       assert(0); // todo: data type
     }
@@ -726,6 +607,11 @@ pimCmdRedSum<T>::execute()
 
   if (!sanityCheck()) {
     return false;
+  }
+
+  if (pimSim::get()->getDeviceType() != PIM_FUNCTIONAL) {
+    pimObjInfo &objSrc = m_device->getResMgr()->getObjInfo(m_src);
+    objSrc.syncFromSimulatedMem(m_device);
   }
 
   const pimObjInfo& objSrc = m_device->getResMgr()->getObjInfo(m_src);
@@ -761,19 +647,13 @@ template <typename T> bool
 pimCmdRedSum<T>::computeRegion(unsigned index)
 {
   const pimObjInfo& objSrc = m_device->getResMgr()->getObjInfo(m_src);
-  bool isVLayout = objSrc.isVLayout();
-  unsigned bitsPerElement = objSrc.getBitsPerElement();
-
   const pimRegion& srcRegion = objSrc.getRegions()[index];
-  PimCoreId coreId = srcRegion.getCoreId();
-  pimCore& core = m_device->getCore(coreId);
 
   unsigned numElementsInRegion = srcRegion.getNumElemInRegion();
   uint64_t currIdx = srcRegion.getElemIdxBegin();
   for (unsigned j = 0; j < numElementsInRegion && currIdx < m_idxEnd; ++j) {
     if (currIdx >= m_idxBegin) {
-      auto locSrc = srcRegion.locateIthElemInRegion(j);
-      uint64_t operandBits = getBits(core, isVLayout, locSrc.first, locSrc.second, bitsPerElement);
+      uint64_t operandBits = objSrc.data().getElementBits(currIdx);
       T operand = pimUtils::signExt(operandBits, objSrc.getDataType());
       m_regionSum[index] += operand;
     }
@@ -834,6 +714,11 @@ pimCmdBroadcast::execute()
   unsigned numRegions = objDest.getRegions().size();
   computeAllRegions(numRegions);
 
+  if (pimSim::get()->getDeviceType() != PIM_FUNCTIONAL) {
+    const pimObjInfo &objDest = m_device->getResMgr()->getObjInfo(m_dest);
+    objDest.syncToSimulatedMem(m_device);
+  }
+
   updateStats();
   return true;
 }
@@ -853,20 +738,14 @@ pimCmdBroadcast::sanityCheck() const
 bool
 pimCmdBroadcast::computeRegion(unsigned index)
 {
-  const pimObjInfo& objDest = m_device->getResMgr()->getObjInfo(m_dest);
-  bool isVLayout = objDest.isVLayout();
-
-  unsigned bitsPerElement = objDest.getBitsPerElement();
-
+  pimObjInfo& objDest = m_device->getResMgr()->getObjInfo(m_dest);
   const pimRegion& destRegion = objDest.getRegions()[index];
-  PimCoreId coreId = destRegion.getCoreId();
-  pimCore &core = m_device->getCore(coreId);
 
+  uint64_t elemIdxBegin = destRegion.getElemIdxBegin();
   unsigned numElementsInRegion = destRegion.getNumElemInRegion();
 
   for (unsigned j = 0; j < numElementsInRegion; ++j) {
-    auto locDest = destRegion.locateIthElemInRegion(j);
-    setBits(core, isVLayout, locDest.first, locDest.second, m_signExtBits, bitsPerElement);
+    objDest.data().setElement(elemIdxBegin + j, m_signExtBits);
   }
   return true;
 }
@@ -897,46 +776,50 @@ pimCmdRotate::execute()
     return false;
   }
 
-  const pimObjInfo& objSrc = m_device->getResMgr()->getObjInfo(m_src);
+  if (pimSim::get()->getDeviceType() != PIM_FUNCTIONAL) {
+    pimObjInfo &objSrc = m_device->getResMgr()->getObjInfo(m_src);
+    objSrc.syncFromSimulatedMem(m_device);
+  }
+
+  pimObjInfo& objSrc = m_device->getResMgr()->getObjInfo(m_src);
   unsigned numRegions = objSrc.getRegions().size();
   m_regionBoundary.resize(numRegions, 0);
 
   computeAllRegions(numRegions);
 
   // handle region boundaries
-  bool isVLayout = objSrc.isVLayout();
-  unsigned bitsPerElement = objSrc.getBitsPerElement();
   if (m_cmdType == PimCmdEnum::ROTATE_ELEM_R || m_cmdType == PimCmdEnum::SHIFT_ELEM_R) {
     for (unsigned i = 0; i < numRegions; ++i) {
       const pimRegion &srcRegion = objSrc.getRegions()[i];
-      unsigned coreId = srcRegion.getCoreId();
-      pimCore &core = m_device->getCore(coreId);
-      auto locSrc = srcRegion.locateIthElemInRegion(0);
+      uint64_t elemIdxBegin = srcRegion.getElemIdxBegin();
       uint64_t val = 0;
       if (i == 0 && m_cmdType == PimCmdEnum::ROTATE_ELEM_R) {
         val = m_regionBoundary[numRegions - 1];
       } else if (i > 0) {
         val = m_regionBoundary[i - 1];
       }
-      setBits(core, isVLayout, locSrc.first, locSrc.second, val, bitsPerElement);
+      objSrc.data().setElement(elemIdxBegin, val);
     }
   } else if (m_cmdType == PimCmdEnum::ROTATE_ELEM_L || m_cmdType == PimCmdEnum::SHIFT_ELEM_L) {
     for (unsigned i = 0; i < numRegions; ++i) {
       const pimRegion &srcRegion = objSrc.getRegions()[i];
-      unsigned coreId = srcRegion.getCoreId();
-      pimCore &core = m_device->getCore(coreId);
       unsigned numElementsInRegion = srcRegion.getNumElemInRegion();
-      auto locSrc = srcRegion.locateIthElemInRegion(numElementsInRegion - 1);
+      uint64_t elemIdxBegin = srcRegion.getElemIdxBegin();
       uint64_t val = 0;
       if (i == numRegions - 1 && m_cmdType == PimCmdEnum::ROTATE_ELEM_L) {
         val = m_regionBoundary[0];
       } else if (i < numRegions - 1) {
         val = m_regionBoundary[i + 1];
       }
-      setBits(core, isVLayout, locSrc.first, locSrc.second, val, bitsPerElement);
+      objSrc.data().setElement(elemIdxBegin + numElementsInRegion - 1, val);
     }
   } else {
     assert(0);
+  }
+
+  if (pimSim::get()->getDeviceType() != PIM_FUNCTIONAL) {
+    const pimObjInfo &objSrc = m_device->getResMgr()->getObjInfo(m_src);
+    objSrc.syncToSimulatedMem(m_device);
   }
 
   updateStats();
@@ -958,20 +841,16 @@ pimCmdRotate::sanityCheck() const
 bool
 pimCmdRotate::computeRegion(unsigned index)
 {
-  const pimObjInfo& objSrc = m_device->getResMgr()->getObjInfo(m_src);
-  bool isVLayout = objSrc.isVLayout();
-  unsigned bitsPerElement = objSrc.getBitsPerElement();
+  pimObjInfo& objSrc = m_device->getResMgr()->getObjInfo(m_src);
 
   const pimRegion& srcRegion = objSrc.getRegions()[index];
-  unsigned coreId = srcRegion.getCoreId();
-  pimCore &core = m_device->getCore(coreId);
 
   // read out values
+  uint64_t elemIdxBegin = srcRegion.getElemIdxBegin();
   unsigned numElementsInRegion = srcRegion.getNumElemInRegion();
   std::vector<uint64_t> regionVector(numElementsInRegion);
   for (unsigned j = 0; j < numElementsInRegion; ++j) {
-    auto locSrc = srcRegion.locateIthElemInRegion(j);
-    regionVector[j] = getBits(core, isVLayout, locSrc.first, locSrc.second, bitsPerElement);
+    regionVector[j] = objSrc.data().getElementBits(elemIdxBegin + j);
   }
 
   // perform rotation
@@ -997,8 +876,7 @@ pimCmdRotate::computeRegion(unsigned index)
 
   // write back values
   for (unsigned j = 0; j < numElementsInRegion; ++j) {
-    auto locSrc = srcRegion.locateIthElemInRegion(j);
-    setBits(core, isVLayout, locSrc.first, locSrc.second, regionVector[j], bitsPerElement);
+    objSrc.data().setElement(elemIdxBegin + j, regionVector[j]);
   }
   return true;
 }

--- a/libpimeval/src/pimCmd.cpp
+++ b/libpimeval/src/pimCmd.cpp
@@ -524,7 +524,7 @@ pimCmdFunc2::computeRegion(unsigned index)
         case PimCmdEnum::MAX: result = (operand1 > operand2) ? operand1 : operand2; break;
         case PimCmdEnum::SCALED_ADD: result = (operand1 * m_scalarValue) + operand2; break;
         default:
-          std::printf("PIM-Error: Unexpected cmd type %d\n", m_cmdType);
+          std::printf("PIM-Error: Unexpected cmd type %d\n", static_cast<int>(m_cmdType));
           assert(0);
         }
         objDest.setElement(elemIdx, result);
@@ -554,7 +554,7 @@ pimCmdFunc2::computeRegion(unsigned index)
         case PimCmdEnum::MAX: result = (operand1 > operand2) ? operand1 : operand2; break;
         case PimCmdEnum::SCALED_ADD: result = (operand1 * m_scalarValue) + operand2; break;
         default:
-          std::printf("PIM-Error: Unexpected cmd type %d\n", m_cmdType);
+          std::printf("PIM-Error: Unexpected cmd type %d\n", static_cast<int>(m_cmdType));
           assert(0);
         }
         objDest.setElement(elemIdx, result);

--- a/libpimeval/src/pimCmd.h
+++ b/libpimeval/src/pimCmd.h
@@ -7,19 +7,18 @@
 #ifndef LAVA_PIM_CMD_H
 #define LAVA_PIM_CMD_H
 
-#include "libpimeval.h"
-#include "pimResMgr.h"
-#include "pimCore.h"
-#include "pimUtils.h"
-#include <vector>
-#include <string>
-#include <bit>
-#include <limits>
-#include <cassert>
-#include <bitset>
+#include "libpimeval.h"      // for PimDataType, PimObjId
+#include "pimResMgr.h"       // for pimResMgr, pimObjInfo
+#include "pimCore.h"         // for pimCore
+#include "pimUtils.h"        // for pimDataTypeEnumToStr, threadWorker
+#include <vector>            // for vector
+#include <string>            // for string
+#include <limits>            // for numeric_limits
+#include <cassert>           // for assert
+#include <bitset>            // for bitset
 
 class pimDevice;
-class pimResMgr;
+
 
 enum class PimCmdEnum {
   NOOP = 0,

--- a/libpimeval/src/pimCmd.h
+++ b/libpimeval/src/pimCmd.h
@@ -173,7 +173,6 @@ public:
   virtual ~pimCmdCopy() {}
   virtual bool execute() override;
   virtual bool sanityCheck() const override;
-  virtual bool computeRegion(unsigned index) override;
   virtual bool updateStats() const override;
 protected:
   PimCopyEnum m_copyType;

--- a/libpimeval/src/pimDevice.cpp
+++ b/libpimeval/src/pimDevice.cpp
@@ -198,7 +198,10 @@ pimDevice::init(PimDeviceEnum deviceType, unsigned numRanks, unsigned numBankPer
   pimPerfEnergyModelParams params(m_simTarget, m_numRanks, paramsDram);
   m_perfEnergyModel = pimPerfEnergyFactory::createPerfEnergyModel(params);
 
-  m_cores.resize(m_numCores, pimCore(m_numRows, m_numCols));
+  // Disable simulated memory creation for functional simulation
+  if (m_deviceType != PIM_FUNCTIONAL) {
+    m_cores.resize(m_numCores, pimCore(m_numRows, m_numCols));
+  }
 
   std::printf("PIM-Info: Created PIM device with %u cores, each with %u rows and %u columns.\n", m_numCores, m_numRows, m_numCols);
 
@@ -291,7 +294,11 @@ pimDevice::init(PimDeviceEnum deviceType, const char* configFileName)
   const pimParamsDram& paramsDram = pimSim::get()->getParamsDram(); // created before pimDevice ctor
   pimPerfEnergyModelParams params(m_simTarget, m_numRanks, paramsDram);
   m_perfEnergyModel = pimPerfEnergyFactory::createPerfEnergyModel(params);
-  m_cores.resize(m_numCores, pimCore(m_numRows, m_numCols));
+
+  // Disable simulated memory creation for functional simulation
+  if (m_deviceType != PIM_FUNCTIONAL) {
+    m_cores.resize(m_numCores, pimCore(m_numRows, m_numCols));
+  }
 
   std::printf("PIM-Info: Created PIM device with %u cores of %u rows and %u columns.\n", m_numCores, m_numRows, m_numCols);
 

--- a/libpimeval/src/pimResMgr.cpp
+++ b/libpimeval/src/pimResMgr.cpp
@@ -6,6 +6,7 @@
 
 #include "pimResMgr.h"       // for pimResMgr
 #include "pimDevice.h"       // for pimDevice
+#include <iostream>          // for cout
 #include <cstdio>            // for printf
 #include <algorithm>         // for sort, prev
 #include <stdexcept>         // for throw, invalid_argument
@@ -263,7 +264,8 @@ pimResMgr::pimAlloc(PimAllocEnum allocType, uint64_t numElements, unsigned bitsP
   #endif
 
   if (numElements == 0 || bitsPerElement == 0) {
-    std::printf("PIM-Error: Invalid parameters to allocate %llu elements of %u bits\n", numElements, bitsPerElement);
+    std::cout << "PIM-Error: Invalid parameters to allocate " << numElements << " elements of "
+              << bitsPerElement << "bits" << std::endl;
     return -1;
   }
 
@@ -308,7 +310,7 @@ pimResMgr::pimAlloc(PimAllocEnum allocType, uint64_t numElements, unsigned bitsP
 
   if (numRegions > numCores) {
     if (allocType == PIM_ALLOC_V1 || allocType == PIM_ALLOC_H1) {
-      std::printf("PIM-Error: Obj requires %llu regions among %u cores. Abort.\n", numRegions, numCores);
+      std::cout << "PIM-Error: Obj requires " << numRegions << " regions among " << numCores << " cores. Abort." << std::endl;
       return -1;
     } else {
       #if defined(DEBUG)

--- a/libpimeval/src/pimResMgr.cpp
+++ b/libpimeval/src/pimResMgr.cpp
@@ -93,7 +93,7 @@ pimObjInfo::copyFromHost(void* src, uint64_t idxBegin, uint64_t idxEnd)
 {
   // handle reference
   if (m_refObjId != -1) {
-    pimObjInfo &refObj = m_device->getResMgr()->getObjInfo(m_refObjId);
+    pimObjInfo& refObj = m_device->getResMgr()->getObjInfo(m_refObjId);
     if (isDualContactRef()) {
       uint64_t numBytes = refObj.m_data.getNumBytes(idxBegin, idxEnd);
       std::vector<uint8_t> buffer(numBytes);
@@ -156,7 +156,7 @@ pimObjInfo::setElementBits(uint64_t index, uint64_t bits)
 {
   // handle reference
   if (m_refObjId != -1) {
-    pimObjInfo &refObj = m_device->getResMgr()->getObjInfo(m_refObjId);
+    pimObjInfo& refObj = m_device->getResMgr()->getObjInfo(m_refObjId);
     if (isDualContactRef()) {
       bits = ~bits;
       refObj.m_data.setElementBits(index, bits);
@@ -174,7 +174,7 @@ pimObjInfo::getElementBits(uint64_t index) const
 {
   // handle reference
   if (m_refObjId != -1) {
-    pimObjInfo &refObj = m_device->getResMgr()->getObjInfo(m_refObjId);
+    pimObjInfo& refObj = m_device->getResMgr()->getObjInfo(m_refObjId);
     if (isDualContactRef()) {
       uint64_t bits = 0;
       refObj.m_data.getElementBits(index, bits);

--- a/libpimeval/src/pimResMgr.cpp
+++ b/libpimeval/src/pimResMgr.cpp
@@ -4,12 +4,14 @@
 // This file is licensed under the MIT License.
 // See the LICENSE file in the root of this repository for more details.
 
-#include "pimResMgr.h"
-#include "pimDevice.h"
-#include <cstdio>
-#include <algorithm>
-#include <stdexcept>
-#include <memory>
+#include "pimResMgr.h"       // for pimResMgr
+#include "pimDevice.h"       // for pimDevice
+#include <cstdio>            // for printf
+#include <algorithm>         // for sort, prev
+#include <stdexcept>         // for throw, invalid_argument
+#include <memory>            // for make_unique
+#include <cassert>           // for assert
+#include <string>            // for string
 
 
 //! @brief  Print info of a PIM region
@@ -84,39 +86,145 @@ pimObjInfo::getRegionsOfCore(PimCoreId coreId) const
   return regions;
 }
 
+//! @brief  Copy data from host memory to PIM object data holder, with ref support
+void
+pimObjInfo::copyFromHost(void* src, uint64_t idxBegin, uint64_t idxEnd)
+{
+  // handle reference
+  if (m_refObjId != -1) {
+    pimObjInfo &refObj = m_device->getResMgr()->getObjInfo(m_refObjId);
+    if (isDualContactRef()) {
+      uint64_t numBytes = refObj.m_data.getNumBytes(idxBegin, idxEnd);
+      std::vector<uint8_t> buffer(numBytes);
+      std::memcpy(buffer.data(), src, numBytes);
+      for (auto& byte : buffer) { byte = ~byte; }
+      refObj.m_data.copyFromHost(buffer.data(), idxBegin, idxEnd);
+    } else {
+      assert(0); // to be extended
+    }
+    return;
+  }
+  m_data.copyFromHost(src, idxBegin, idxEnd);
+}
+
+//! @brief  Copy data from PIM object data holder to host memory, with ref support
+void
+pimObjInfo::copyToHost(void* dest, uint64_t idxBegin, uint64_t idxEnd) const
+{
+  // handle reference
+  if (m_refObjId != -1) {
+    pimObjInfo &refObj = m_device->getResMgr()->getObjInfo(m_refObjId);
+    if (isDualContactRef()) {
+      uint64_t numBytes = refObj.m_data.getNumBytes(idxBegin, idxEnd);
+      std::vector<uint8_t> buffer(numBytes);
+      refObj.m_data.copyToHost(buffer.data(), idxBegin, idxEnd);
+      for (auto& byte : buffer) { byte = ~byte; }
+      std::memcpy(dest, buffer.data(), numBytes);
+    } else {
+      assert(0); // to be extended
+    }
+    return;
+  }
+  m_data.copyToHost(dest, idxBegin, idxEnd);
+}
+
+//! @brief  Copy data from a PIM object data holder to another, with ref support
+void
+pimObjInfo::copyToObj(pimObjInfo& destObj, uint64_t idxBegin, uint64_t idxEnd) const
+{
+  // handle reference
+  if (m_refObjId != -1) {
+    pimObjInfo &refObj = m_device->getResMgr()->getObjInfo(m_refObjId);
+    if (isDualContactRef()) {
+      uint64_t numBytes = m_data.getNumBytes(idxBegin, idxEnd);
+      std::vector<uint8_t> buffer(numBytes);
+      m_data.copyToHost(buffer.data(), idxBegin, idxEnd);
+      for (auto& byte : buffer) { byte = ~byte; }
+      refObj.m_data.copyFromHost(buffer.data(), idxBegin, idxEnd);
+    } else {
+      assert(0); // to be extended
+    }
+    return;
+  }
+  m_data.copyToObj(destObj.m_data, idxBegin, idxEnd);
+}
+
+//! @brief  Set an element at index with bit presentation, with ref support
+void
+pimObjInfo::setElementBits(uint64_t index, uint64_t bits)
+{
+  // handle reference
+  if (m_refObjId != -1) {
+    pimObjInfo &refObj = m_device->getResMgr()->getObjInfo(m_refObjId);
+    if (isDualContactRef()) {
+      bits = ~bits;
+      refObj.m_data.setElementBits(index, bits);
+    } else {
+      assert(0); // to be extended
+    }
+    return;
+  }
+  m_data.setElementBits(index, bits);
+}
+
+//! @brief  Get bit representation of an element at index, with ref support
+uint64_t
+pimObjInfo::getElementBits(uint64_t index) const
+{
+  // handle reference
+  if (m_refObjId != -1) {
+    pimObjInfo &refObj = m_device->getResMgr()->getObjInfo(m_refObjId);
+    if (isDualContactRef()) {
+      uint64_t bits = 0;
+      refObj.m_data.getElementBits(index, bits);
+      bits = ~bits;
+      return bits;
+    } else {
+      assert(0); // to be extended
+    }
+    return 0;
+  }
+  uint64_t bits = 0;
+  m_data.getElementBits(index, bits);
+  return bits;
+}
+
 //! @brief  Sync PIM object data from simulated memory
 void
-pimObjInfo::syncFromSimulatedMem(pimDevice *device)
+pimObjInfo::syncFromSimulatedMem()
 {
+  pimObjInfo &obj = (m_refObjId != -1 ? m_device->getResMgr()->getObjInfo(m_refObjId) : *this);
   unsigned numBits = getBitsPerElement();
   for (size_t i = 0; i < m_regions.size(); ++i) {
     pimRegion& region = m_regions[i];
     PimCoreId coreId = region.getCoreId();
-    pimCore& core = device->getCore(coreId);
+    pimCore& core = m_device->getCore(coreId);
     uint64_t elemIdxBegin = region.getElemIdxBegin();
     uint64_t numElemInRegion = region.getNumElemInRegion();
     for (uint64_t j = 0; j < numElemInRegion; ++j) {
       auto [rowLoc, colLoc] = region.locateIthElemInRegion(j);
       uint64_t bits = isVLayout() ? core.getBitsV(rowLoc, colLoc, numBits)
                                   : core.getBitsH(rowLoc, colLoc, numBits);
-      m_data.setElement(elemIdxBegin + j, bits);
+      obj.m_data.setElementBits(elemIdxBegin + j, bits);
     }
   }
 }
 
 //! @brief  Sync PIM object data to simulated memory
 void
-pimObjInfo::syncToSimulatedMem(pimDevice *device) const
+pimObjInfo::syncToSimulatedMem() const
 {
+  const pimObjInfo &obj = (m_refObjId != -1 ? m_device->getResMgr()->getObjInfo(m_refObjId) : *this);
   unsigned numBits = getBitsPerElement();
   for (size_t i = 0; i < m_regions.size(); ++i) {
     const pimRegion& region = m_regions[i];
     PimCoreId coreId = region.getCoreId();
-    pimCore& core = device->getCore(coreId);
+    pimCore& core = m_device->getCore(coreId);
     uint64_t elemIdxBegin = region.getElemIdxBegin();
     uint64_t numElemInRegion = region.getNumElemInRegion();
     for (uint64_t j = 0; j < numElemInRegion; ++j) {
-      uint64_t bits = m_data.getElementBits(elemIdxBegin + j);
+      uint64_t bits = 0;
+      obj.m_data.getElementBits(elemIdxBegin + j, bits);
       auto [rowLoc, colLoc] = region.locateIthElemInRegion(j);
       if (isVLayout()) {
         core.setBitsV(rowLoc, colLoc, bits, numBits);
@@ -160,7 +268,7 @@ pimResMgr::pimAlloc(PimAllocEnum allocType, uint64_t numElements, unsigned bitsP
   }
 
   std::vector<PimCoreId> sortedCoreId = getCoreIdsSortedByLeastUsage();
-  pimObjInfo newObj(m_availObjId, dataType, allocType, numElements, bitsPerElement);
+  pimObjInfo newObj(m_availObjId, dataType, allocType, numElements, bitsPerElement, m_device);
   m_availObjId++;
 
   unsigned numCores = m_device->getNumCores();
@@ -295,7 +403,7 @@ pimResMgr::pimAllocAssociated(unsigned bitsPerElement, PimObjId assocId, PimData
   assert(allocType == assocObj.getAllocType());
 
   // allocate associated regions
-  pimObjInfo newObj(m_availObjId, dataType, allocType, numElements, bitsPerElement);
+  pimObjInfo newObj(m_availObjId, dataType, allocType, numElements, bitsPerElement, m_device);
   m_availObjId++;
 
   bool success = true;

--- a/libpimeval/src/pimResMgr.h
+++ b/libpimeval/src/pimResMgr.h
@@ -16,6 +16,7 @@
 #include <string>            // for string
 #include <memory>            // for unique_ptr
 #include <cassert>           // for assert
+#include <iostream>          // for cout
 
 class pimDevice;
 
@@ -138,10 +139,11 @@ public:
     return true;
   }
 
-  // print all bytes
+  // print all bytes for debugging
   void print() const {
-    std::printf("DEBUG: data-type = %s, num-elements = %llu, byts-per-element = %u\n",
-        pimUtils::pimDataTypeEnumToStr(m_dataType).c_str(), m_numElements, m_bytesPerElement);
+    std::cout << "PIM obj data holder: data-type = " << pimUtils::pimDataTypeEnumToStr(m_dataType)
+              << ", num-elements = " << m_numElements
+              << ", bytes-per-element = " << m_bytesPerElement << std::endl;
     for (size_t i = 0; i < m_data.size(); ++i) {
       std::printf(" %02x", m_data[i]);
       if ((i + 1) % 64 == 0) { std::printf("\n"); }

--- a/libpimeval/src/pimStats.cpp
+++ b/libpimeval/src/pimStats.cpp
@@ -7,7 +7,11 @@
 #include "pimStats.h"
 #include "pimSim.h"
 #include "pimUtils.h"
-#include <algorithm>
+#include <chrono>            // for chrono
+#include <cstdint>           // for uint64_t
+#include <cstdio>            // for printf
+#include <iostream>          // for cout
+#include <iomanip>           // for setw, fixed, setprecision
 
 
 //! @brief  Show PIM stats
@@ -104,10 +108,13 @@ pimStatsMgr::showCopyStats() const
   uint64_t totalBytes = bytesCopiedMainToDevice + bytesCopiedDeviceToMain;
   double totalMsRuntime = m_elapsedTimeCopiedMainToDevice + m_elapsedTimeCopiedDeviceToMain + m_elapsedTimeCopiedDeviceToDevice;
   double totalMjEnergy = m_mJCopiedMainToDevice + m_mJCopiedDeviceToMain + m_mJCopiedDeviceToDevice;
-  std::printf(" %44s : %llu bytes\n", "Host to Device", bytesCopiedMainToDevice);
-  std::printf(" %44s : %llu bytes\n", "Device to Host", bytesCopiedDeviceToMain);
-  std::printf(" %44s : %llu bytes\n", "Device to Device", bytesCopiedDeviceToDevice);
-  std::printf(" %44s : %llu bytes %14f ms Estimated Runtime %14f mj Estimated Energy\n", "TOTAL ---------", totalBytes, totalMsRuntime, totalMjEnergy);
+  std::cout << std::setw(45) << "Host to Device" << " : " << bytesCopiedMainToDevice << " bytes" << std::endl;
+  std::cout << std::setw(45) << "Device to Host" << " : " << bytesCopiedDeviceToMain << " bytes" << std::endl;
+  std::cout << std::setw(45) << "Device to Device" << " : " << bytesCopiedDeviceToDevice << " bytes" << std::endl;
+  std::cout << std::setw(45) << "TOTAL ---------" << " : " << totalBytes << " bytes "
+            << std::setw(14) << std::fixed << std::setprecision(6) << totalMsRuntime << " ms Estimated Runtime "
+            << std::setw(14) << std::fixed << std::setprecision(6) << totalMjEnergy << " mj Estimated Energy"
+            << std::endl;
 }
 
 //! @brief  Show PIM cmd and perf stats

--- a/tests/test-functional/result-golden.txt
+++ b/tests/test-functional/result-golden.txt
@@ -8,7 +8,7 @@ PIM-Info: Config: #ranks = 1, #bankPerRank = 1, #subarrayPerBank = 4, #rowsPerSu
 PIM-Info: Aggregate every two subarrays as a single core
 PIM-Info: Created performance energy model for bit-serial PIM
 PIM-Info: Created PIM device with 2 cores, each with 2048 rows and 256 columns.
-PIM-Info: Created thread pool with 9 threads.
+PIM-Info: Created thread pool with # threads.
 ================================================================
 INFO: PIMeval Functional Tests for INT8
 ================================================================
@@ -900,7 +900,7 @@ PIM-Info: Config: #ranks = 1, #bankPerRank = 1, #subarrayPerBank = 4, #rowsPerSu
 PIM-Info: Aggregate every two subarrays as a single core
 PIM-Info: Created performance energy model for Fulcrum
 PIM-Info: Created PIM device with 2 cores, each with 2048 rows and 256 columns.
-PIM-Info: Created thread pool with 9 threads.
+PIM-Info: Created thread pool with # threads.
 ================================================================
 INFO: PIMeval Functional Tests for INT8
 ================================================================
@@ -1777,7 +1777,7 @@ PIM-Info: Config: #ranks = 1, #bankPerRank = 1, #subarrayPerBank = 4, #rowsPerSu
 PIM-Info: Aggregate all subarrays within a bank as a single core
 PIM-Info: Created performance energy model for bank-level PIM
 PIM-Info: Created PIM device with 1 cores, each with 4096 rows and 256 columns.
-PIM-Info: Created thread pool with 9 threads.
+PIM-Info: Created thread pool with # threads.
 ================================================================
 INFO: PIMeval Functional Tests for INT8
 ================================================================

--- a/tests/test-functional/run-pre-commit-tests.sh
+++ b/tests/test-functional/run-pre-commit-tests.sh
@@ -21,13 +21,13 @@ echo "PIMeval Functional Testing Results" | tee -a $LOCAL
 echo "##################################" | tee -a $LOCAL
 
 export PIMEVAL_TARGET=PIM_DEVICE_BITSIMD_V_AP
-$SCRIPT_DIR/test-functional.out | tee -a $LOCAL
+$SCRIPT_DIR/test-functional.out 2>&1 | tee -a $LOCAL
 
 export PIMEVAL_TARGET=PIM_DEVICE_FULCRUM
-$SCRIPT_DIR/test-functional.out | tee -a $LOCAL
+$SCRIPT_DIR/test-functional.out 2>&1 | tee -a $LOCAL
 
 export PIMEVAL_TARGET=PIM_DEVICE_BANK_LEVEL
-$SCRIPT_DIR/test-functional.out | tee -a $LOCAL
+$SCRIPT_DIR/test-functional.out 2>&1 | tee -a $LOCAL
 
 
 # STEP 2: Compare result_local.txt with result_golden.txt

--- a/tests/test-functional/run-pre-commit-tests.sh
+++ b/tests/test-functional/run-pre-commit-tests.sh
@@ -29,6 +29,8 @@ $SCRIPT_DIR/test-functional.out 2>&1 | tee -a $LOCAL
 export PIMEVAL_TARGET=PIM_DEVICE_BANK_LEVEL
 $SCRIPT_DIR/test-functional.out 2>&1 | tee -a $LOCAL
 
+# replace number of threads with #
+sed -i 's/thread pool with [0-9]\+ threads/thread pool with # threads/g' $LOCAL
 
 # STEP 2: Compare result_local.txt with result_golden.txt
 #         Catch any differences between the two

--- a/tests/test-functional/run-pre-commit-tests.sh
+++ b/tests/test-functional/run-pre-commit-tests.sh
@@ -30,7 +30,11 @@ export PIMEVAL_TARGET=PIM_DEVICE_BANK_LEVEL
 $SCRIPT_DIR/test-functional.out 2>&1 | tee -a $LOCAL
 
 # replace number of threads with #
-sed -i 's/thread pool with [0-9]\+ threads/thread pool with # threads/g' $LOCAL
+if [[ "$OSTYPE" == "darwin"* ]]; then # OSX
+    sed -i '' 's/thread pool with [0-9]* threads/thread pool with # threads/g' $LOCAL
+else # Linux
+    sed -i 's/thread pool with [0-9]* threads/thread pool with # threads/g' $LOCAL
+fi
 
 # STEP 2: Compare result_local.txt with result_golden.txt
 #         Catch any differences between the two


### PR DESCRIPTION
Major PIMeval simulator upgrade for functional simulation memory and runtime.

Key designs:
* Support two ways of storing PIM object data
  - In the data holder per PIM object, as a byte array for fast functional simulation
  - In the simulated PIM memory, i.e., pimCore, for detailed memory behavior simulation such as row read/write. The simulated PIM memory is only instantiated for non-functional simulation
  - All the PIM memory allocation metadata in pimObjInfo and pimRegion are maintained with no change, for performance modeling and future extension
* Code organization
  - In pimResMgr.h, create pimDataHolder class
  - In pimResMgr.h/cpp, create APIs in pimObjInfo for accessing the data holder, syncing data between data holder and simulated memory, and supporting reference objects
  - In pimDevice.cpp, disable simulated memory initialization in functional simulation mode
  - In pimCmd.cpp, instead of getting operands and saving results from/to simulated memory, use the data holder in functional simulation commands. Add additional syncing APIs for supporting mixed functional and micro-ops usage in non-functional mode.

Testing:
- test-functional for functional simulation
- bit-serial for non-functional simulation with mixed functional and micro-ops APIs
- test-simdram for dual-contact rows
- PIMbench apps

This closes Issue #166.