### PR TITLE
FP32 functional support for all operation completed!

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -25,9 +25,9 @@ ifeq ($(MAKECMDGOALS),debug)
 	CXXFLAGS += -g -DDEBUG
 endif
 ifeq ($(MAKECMDGOALS),perf)
-	CXXFLAGS += -Ofast -Wno-unknown-pragmas
+	CXXFLAGS += -O3 -Wno-unknown-pragmas
 endif
 ifeq ($(MAKECMDGOALS),dramsim3_integ)
-	CXXFLAGS += -Ofast -DDRAMSIM3_INTEG
+	CXXFLAGS += -O3 -DDRAMSIM3_INTEG
 endif
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ PIMeval-PIMbench/
 <!--
 ### How To Build
 * Run `make` at root directory or subdirectories
-  * `make perf`: Build with `-Ofast` for performance measurement (default)
+  * `make perf`: Build with `-O3` for performance measurement (default)
   * `make debug`: Build with `-g` and `-DDEBUG` for debugging and printing verbose messages
 * Multi-threaded building
   * `make -j<n_proc>`

--- a/libpimeval/Makefile
+++ b/libpimeval/Makefile
@@ -7,7 +7,7 @@ CXX := g++
 CXXFLAGS := -Wall -Wextra -std=c++17
 CXXFLAGS_DEBUG := -g
 # Note: If specify -DNDEBUG, assert will be disabled
-CXXFLAGS_PERF := -Ofast -Wno-unused-parameter
+CXXFLAGS_PERF := -O3 -Wno-unused-parameter
 INC :=
 AR := ar
 ARFLAGS := rcs

--- a/libpimeval/src/libpimeval.cpp
+++ b/libpimeval/src/libpimeval.cpp
@@ -377,6 +377,14 @@ pimRedSumUInt(PimObjId src, uint64_t* sum)
   return ok ? PIM_OK : PIM_ERROR;
 }
 
+//! @brief  PIM reduction sum for float. Result returned to a host variable
+PimStatus
+pimRedSumFP32(PimObjId src, float* sum)
+{
+  bool ok = pimSim::get()->pimRedSum(src, sum);
+  return ok ? PIM_OK : PIM_ERROR;
+}
+
 //! @brief  PIM reduction sum for a range of an signed int obj. Result returned to a host variable
 PimStatus
 pimRedSumRangedInt(PimObjId src, uint64_t idxBegin, uint64_t idxEnd, int64_t* sum)
@@ -388,6 +396,14 @@ pimRedSumRangedInt(PimObjId src, uint64_t idxBegin, uint64_t idxEnd, int64_t* su
 //! @brief  PIM reduction sum for a range of an unsigned int obj. Result returned to a host variable
 PimStatus
 pimRedSumRangedUInt(PimObjId src, uint64_t idxBegin, uint64_t idxEnd, uint64_t* sum)
+{
+  bool ok = pimSim::get()->pimRedSumRanged(src, idxBegin, idxEnd, sum);
+  return ok ? PIM_OK : PIM_ERROR;
+}
+
+//! @brief  PIM reduction sum for a range of an float obj. Result returned to a host variable
+PimStatus
+pimRedSumRangedFP32(PimObjId src, uint64_t idxBegin, uint64_t idxEnd, float* sum)
 {
   bool ok = pimSim::get()->pimRedSumRanged(src, idxBegin, idxEnd, sum);
   return ok ? PIM_OK : PIM_ERROR;

--- a/libpimeval/src/libpimeval.h
+++ b/libpimeval/src/libpimeval.h
@@ -146,9 +146,11 @@ PimStatus pimScaledAdd(PimObjId src1, PimObjId src2, PimObjId dest, uint64_t sca
 PimStatus pimPopCount(PimObjId src, PimObjId dest);
 PimStatus pimRedSumInt(PimObjId src, int64_t* sum);
 PimStatus pimRedSumUInt(PimObjId src, uint64_t* sum);
+PimStatus pimRedSumFP32(PimObjId src, float* sum);
 // Note: Reduction sum range is [idxBegin, idxEnd)
 PimStatus pimRedSumRangedInt(PimObjId src, uint64_t idxBegin, uint64_t idxEnd, int64_t* sum);
 PimStatus pimRedSumRangedUInt(PimObjId src, uint64_t idxBegin, uint64_t idxEnd, uint64_t* sum);
+PimStatus pimRedSumRangedFP32(PimObjId src, uint64_t idxBegin, uint64_t idxEnd, float* sum);
 PimStatus pimBroadcastInt(PimObjId dest, int64_t value);
 PimStatus pimBroadcastUInt(PimObjId dest, uint64_t value);
 PimStatus pimBroadcastFP32(PimObjId dest, float value);

--- a/libpimeval/src/pimCmd.cpp
+++ b/libpimeval/src/pimCmd.cpp
@@ -598,7 +598,7 @@ pimCmdRedSum<T>::computeRegion(unsigned index)
     if (currIdx >= m_idxBegin) {
       uint64_t operandBits = objSrc.getElementBits(currIdx);
       bool isFP = (dataType == PIM_FP32);
-      if(!isFP){
+      if (!isFP) {
         T integerOperand = pimUtils::signExt(operandBits, dataType);
         m_regionSum[index] += integerOperand;
       } else if (isFP){

--- a/libpimeval/src/pimCmd.cpp
+++ b/libpimeval/src/pimCmd.cpp
@@ -407,7 +407,7 @@ pimCmdFunc1::computeRegion(unsigned index)
       if(!computeResultFP(floatOperand, m_cmdType, pimUtils::castBitsToType<float>(m_scalarValue), result)) return false;
       objDest.setElement(elemIdx, result);
     } else {
-    assert(0); // todo: data type
+      assert(0); // todo: data type
     }
   }
   return true;

--- a/libpimeval/src/pimCmd.cpp
+++ b/libpimeval/src/pimCmd.cpp
@@ -394,7 +394,7 @@ pimCmdFunc1::computeRegion(unsigned index)
         int64_t result = 0;
         if(!computeResult(signedOperand, m_cmdType, (int64_t)m_scalarValue, result, bitsPerElementSrc)) return false;
         objDest.setElement(elemIdx, result);
-      } else if (dataType != PIM_FP32) { // signed int.
+      } else if (dataType != PIM_FP32) { // unsigned int.
         uint64_t unsignedOperand = objSrc.getElementBits(elemIdx);
         uint64_t result = 0;
         if(!computeResult(unsignedOperand, m_cmdType, m_scalarValue, result, bitsPerElementSrc)) return false;
@@ -403,7 +403,7 @@ pimCmdFunc1::computeRegion(unsigned index)
         uint64_t bits = objSrc.getElementBits(elemIdx);
         float floatOperand = pimUtils::castBitsToType<float>(bits);
         float result = 0.0;
-        if(!computeResultFP(floatOperand, m_cmdType, pimUtils::castBitsToType<float>(m_scalarValue), result, bitsPerElementSrc)) return false;
+        if(!computeResultFP(floatOperand, m_cmdType, pimUtils::castBitsToType<float>(m_scalarValue), result)) return false;
         objDest.setElement(elemIdx, result);
       } else {
       assert(0); // todo: data type
@@ -493,96 +493,33 @@ pimCmdFunc2::computeRegion(unsigned index)
   unsigned numElementsInRegion = src1Region.getNumElemInRegion();
   for (unsigned j = 0; j < numElementsInRegion; ++j) {
     uint64_t elemIdx = elemIdxBegin + j;
-
-    if (dataType == PIM_INT8 || dataType == PIM_INT16 || dataType == PIM_INT32 || dataType == PIM_INT64 || dataType == PIM_UINT8 || dataType == PIM_UINT16 || dataType == PIM_UINT32 || dataType == PIM_UINT64) {
-      uint64_t operandBits1 = objSrc1.getElementBits(elemIdx);
-      uint64_t operandBits2 = objSrc2.getElementBits(elemIdx);
-      // The following if-else block is the perfect example of where a Template would have been much more cleaner and efficient and less error prone
-      if (dataType == PIM_INT8 || dataType == PIM_INT16 || dataType == PIM_INT32 || dataType == PIM_INT64) {
+    if (dataType == PIM_INT8 || dataType == PIM_INT16 || dataType == PIM_INT32 || dataType == PIM_INT64 || dataType == PIM_UINT8 || dataType == PIM_UINT16 || dataType == PIM_UINT32 || dataType == PIM_UINT64 || dataType == PIM_FP32) {
+      bool isSigned = (dataType == PIM_INT8 || dataType == PIM_INT16 || dataType == PIM_INT32 || dataType == PIM_INT64);
+      if (isSigned) {
+        uint64_t operandBits1 = objSrc1.getElementBits(elemIdx);
+        uint64_t operandBits2 = objSrc2.getElementBits(elemIdx);
         int64_t operand1 = pimUtils::signExt(operandBits1, dataType);
         int64_t operand2 = pimUtils::signExt(operandBits2, dataType);
         int64_t result = 0;
-        switch (m_cmdType) {
-        case PimCmdEnum::ADD: result = operand1 + operand2; break;
-        case PimCmdEnum::SUB: result = operand1 - operand2; break;
-        case PimCmdEnum::MUL: result = operand1 * operand2; break;
-        case PimCmdEnum::DIV:
-          if (operand2 == 0) {
-            std::printf("PIM-Error: Division by zero\n");
-            return false;
-          }
-          result = operand1 / operand2;
-          break;
-        case PimCmdEnum::AND: result = operand1 & operand2; break;
-        case PimCmdEnum::OR: result = operand1 | operand2; break;
-        case PimCmdEnum::XOR: result = operand1 ^ operand2; break;
-        case PimCmdEnum::XNOR: result = ~(operand1 ^ operand2); break;
-        case PimCmdEnum::GT: result = operand1 > operand2 ? 1 : 0; break;
-        case PimCmdEnum::LT: result = operand1 < operand2 ? 1 : 0; break;
-        case PimCmdEnum::EQ: result = operand1 == operand2 ? 1 : 0; break;
-        case PimCmdEnum::MIN: result = (operand1 < operand2) ? operand1 : operand2; break;
-        case PimCmdEnum::MAX: result = (operand1 > operand2) ? operand1 : operand2; break;
-        case PimCmdEnum::SCALED_ADD: result = (operand1 * m_scalarValue) + operand2; break;
-        default:
-          std::printf("PIM-Error: Unexpected cmd type %d\n", static_cast<int>(m_cmdType));
-          assert(0);
-        }
+        if(!computeResult(operand1, operand2, m_cmdType, (int64_t)m_scalarValue, result)) return false;
+        objDest.setElement(elemIdx, result);
+      } else if (dataType != PIM_FP32) { // unsigned int.
+        uint64_t unsignedOperand1 = objSrc1.getElementBits(elemIdx);
+        uint64_t unsignedOperand2 = objSrc2.getElementBits(elemIdx);
+        uint64_t result = 0;
+        if(!computeResult(unsignedOperand1, unsignedOperand2, m_cmdType, m_scalarValue, result)) return false;
+        objDest.setElement(elemIdx, result);
+      } else if (dataType == PIM_FP32){
+        uint64_t bits1 = objSrc1.getElementBits(elemIdx);
+        uint64_t bits2 = objSrc2.getElementBits(elemIdx);
+        float floatOperand1 = pimUtils::castBitsToType<float>(bits1);
+        float floatOperand2 = pimUtils::castBitsToType<float>(bits2);
+        float result = 0.0;
+        if(!computeResultFP(floatOperand1, floatOperand2, m_cmdType, pimUtils::castBitsToType<float>(m_scalarValue), result)) return false;
         objDest.setElement(elemIdx, result);
       } else {
-        uint64_t operand1 = operandBits1;
-        uint64_t operand2 = operandBits2;
-        uint64_t result = 0;
-        switch (m_cmdType) {
-        case PimCmdEnum::ADD: result = operand1 + operand2; break;
-        case PimCmdEnum::SUB: result = operand1 - operand2; break;
-        case PimCmdEnum::MUL: result = operand1 * operand2; break;
-        case PimCmdEnum::DIV:
-          if (operand2 == 0) {
-            std::printf("PIM-Error: Division by zero\n");
-            return false;
-          }
-          result = operand1 / operand2;
-          break;
-        case PimCmdEnum::AND: result = operand1 & operand2; break;
-        case PimCmdEnum::OR: result = operand1 | operand2; break;
-        case PimCmdEnum::XOR: result = operand1 ^ operand2; break;
-        case PimCmdEnum::XNOR: result = ~(operand1 ^ operand2); break;
-        case PimCmdEnum::GT: result = operand1 > operand2 ? 1 : 0; break;
-        case PimCmdEnum::LT: result = operand1 < operand2 ? 1 : 0; break;
-        case PimCmdEnum::EQ: result = operand1 == operand2 ? 1 : 0; break;
-        case PimCmdEnum::MIN: result = (operand1 < operand2) ? operand1 : operand2; break;
-        case PimCmdEnum::MAX: result = (operand1 > operand2) ? operand1 : operand2; break;
-        case PimCmdEnum::SCALED_ADD: result = (operand1 * m_scalarValue) + operand2; break;
-        default:
-          std::printf("PIM-Error: Unexpected cmd type %d\n", static_cast<int>(m_cmdType));
-          assert(0);
-        }
-        objDest.setElement(elemIdx, result);
-      }
-    } else if (dataType == PIM_FP32) {
-      uint64_t operandBits1 = objSrc1.getElementBits(elemIdx);
-      uint64_t operandBits2 = objSrc2.getElementBits(elemIdx);
-      float operand1 = pimUtils::castBitsToType<float>(operandBits1);
-      float operand2 = pimUtils::castBitsToType<float>(operandBits2);
-      float result = 0;
-      switch (m_cmdType) {
-      case PimCmdEnum::ADD: result = operand1 + operand2; break;
-      case PimCmdEnum::SUB: result = operand1 - operand2; break;
-      case PimCmdEnum::MUL: result = operand1 * operand2; break;
-      case PimCmdEnum::DIV:
-        if (operand2 == 0) {
-          std::printf("PIM-Error: Division by zero\n");
-          return false;
-        }
-        result = operand1 / operand2;
-        break;
-      default:
-        std::printf("PIM-Error: Unsupported FP32 cmd type %d\n", static_cast<int>(m_cmdType));
-        assert(0);
-      }
-      objDest.setElement(elemIdx, result);
-    } else {
       assert(0); // todo: data type
+      }
     }
   }
   return true;
@@ -659,7 +596,7 @@ pimCmdRedSum<T>::computeRegion(unsigned index)
   for (unsigned j = 0; j < numElementsInRegion && currIdx < m_idxEnd; ++j) {
     if (currIdx >= m_idxBegin) {
       uint64_t operandBits = objSrc.getElementBits(currIdx);
-      T operand = pimUtils::signExt(operandBits, objSrc.getDataType());
+      T operand = pimUtils::signExt(operandBits, objSrc.getDataType()); // How do we incorporate FP32 in here?
       m_regionSum[index] += operand;
     }
     currIdx += 1;
@@ -1218,3 +1155,4 @@ pimCmdAnalogAAP::printDebugInfo() const
 // Explicit template instantiation
 template class pimCmdRedSum<uint64_t>;
 template class pimCmdRedSum<int64_t>;
+template class pimCmdRedSum<float>;

--- a/libpimeval/src/pimCmd.cpp
+++ b/libpimeval/src/pimCmd.cpp
@@ -389,17 +389,19 @@ pimCmdFunc1::computeRegion(unsigned index)
     uint64_t elemIdx = elemIdxBegin + j;
     if (dataType == PIM_INT8 || dataType == PIM_INT16 || dataType == PIM_INT32 || dataType == PIM_INT64 || dataType == PIM_UINT8 || dataType == PIM_UINT16 || dataType == PIM_UINT32 || dataType == PIM_UINT64 || dataType == PIM_FP32) {
       bool isSigned = (dataType == PIM_INT8 || dataType == PIM_INT16 || dataType == PIM_INT32 || dataType == PIM_INT64);
+      bool isUnsigned = (dataType == PIM_UINT8 || dataType == PIM_UINT16 || dataType == PIM_UINT32 || dataType == PIM_UINT64);
+      bool isFP = (dataType == PIM_FP32);
       if (isSigned) {
         int64_t signedOperand = objSrc.getElementBits(elemIdx);
         int64_t result = 0;
         if(!computeResult(signedOperand, m_cmdType, (int64_t)m_scalarValue, result, bitsPerElementSrc)) return false;
         objDest.setElement(elemIdx, result);
-      } else if (dataType != PIM_FP32) { // unsigned int.
+      } else if (isUnsigned) {
         uint64_t unsignedOperand = objSrc.getElementBits(elemIdx);
         uint64_t result = 0;
         if(!computeResult(unsignedOperand, m_cmdType, m_scalarValue, result, bitsPerElementSrc)) return false;
         objDest.setElement(elemIdx, result);
-      } else if (dataType == PIM_FP32){
+      } else if (isFP){
         uint64_t bits = objSrc.getElementBits(elemIdx);
         float floatOperand = pimUtils::castBitsToType<float>(bits);
         float result = 0.0;
@@ -495,6 +497,8 @@ pimCmdFunc2::computeRegion(unsigned index)
     uint64_t elemIdx = elemIdxBegin + j;
     if (dataType == PIM_INT8 || dataType == PIM_INT16 || dataType == PIM_INT32 || dataType == PIM_INT64 || dataType == PIM_UINT8 || dataType == PIM_UINT16 || dataType == PIM_UINT32 || dataType == PIM_UINT64 || dataType == PIM_FP32) {
       bool isSigned = (dataType == PIM_INT8 || dataType == PIM_INT16 || dataType == PIM_INT32 || dataType == PIM_INT64);
+      bool isUnsigned = (dataType == PIM_UINT8 || dataType == PIM_UINT16 || dataType == PIM_UINT32 || dataType == PIM_UINT64);
+      bool isFP = (dataType == PIM_FP32);
       if (isSigned) {
         uint64_t operandBits1 = objSrc1.getElementBits(elemIdx);
         uint64_t operandBits2 = objSrc2.getElementBits(elemIdx);
@@ -503,17 +507,17 @@ pimCmdFunc2::computeRegion(unsigned index)
         int64_t result = 0;
         if(!computeResult(operand1, operand2, m_cmdType, (int64_t)m_scalarValue, result)) return false;
         objDest.setElement(elemIdx, result);
-      } else if (dataType != PIM_FP32) { // unsigned int.
+      } else if (isUnsigned) {
         uint64_t unsignedOperand1 = objSrc1.getElementBits(elemIdx);
         uint64_t unsignedOperand2 = objSrc2.getElementBits(elemIdx);
         uint64_t result = 0;
         if(!computeResult(unsignedOperand1, unsignedOperand2, m_cmdType, m_scalarValue, result)) return false;
         objDest.setElement(elemIdx, result);
-      } else if (dataType == PIM_FP32){
-        uint64_t bits1 = objSrc1.getElementBits(elemIdx);
-        uint64_t bits2 = objSrc2.getElementBits(elemIdx);
-        float floatOperand1 = pimUtils::castBitsToType<float>(bits1);
-        float floatOperand2 = pimUtils::castBitsToType<float>(bits2);
+      } else if (isFP){
+        uint64_t operandBits1 = objSrc1.getElementBits(elemIdx);
+        uint64_t operandBits2 = objSrc2.getElementBits(elemIdx);
+        float floatOperand1 = pimUtils::castBitsToType<float>(operandBits1);
+        float floatOperand2 = pimUtils::castBitsToType<float>(operandBits2);
         float result = 0.0;
         if(!computeResultFP(floatOperand1, floatOperand2, m_cmdType, pimUtils::castBitsToType<float>(m_scalarValue), result)) return false;
         objDest.setElement(elemIdx, result);
@@ -597,11 +601,11 @@ pimCmdRedSum<T>::computeRegion(unsigned index)
   for (unsigned j = 0; j < numElementsInRegion && currIdx < m_idxEnd; ++j) {
     if (currIdx >= m_idxBegin) {
       uint64_t operandBits = objSrc.getElementBits(currIdx);
-      bool isFloat = (dataType == PIM_FP32);
-      if(!isFloat){
+      bool isFP = (dataType == PIM_FP32);
+      if(!isFP){
         T integerOperand = pimUtils::signExt(operandBits, dataType);
         m_regionSum[index] += integerOperand;
-      } else if (isFloat){
+      } else if (isFP){
         float floatOperand = pimUtils::castBitsToType<float>(operandBits);
         m_regionSum[index] += floatOperand;
       } else {

--- a/libpimeval/src/pimCmd.cpp
+++ b/libpimeval/src/pimCmd.cpp
@@ -387,29 +387,27 @@ pimCmdFunc1::computeRegion(unsigned index)
   unsigned numElementsInRegion = srcRegion.getNumElemInRegion();
   for (unsigned j = 0; j < numElementsInRegion; ++j) {
     uint64_t elemIdx = elemIdxBegin + j;
-    if (dataType == PIM_INT8 || dataType == PIM_INT16 || dataType == PIM_INT32 || dataType == PIM_INT64 || dataType == PIM_UINT8 || dataType == PIM_UINT16 || dataType == PIM_UINT32 || dataType == PIM_UINT64 || dataType == PIM_FP32) {
-      bool isSigned = (dataType == PIM_INT8 || dataType == PIM_INT16 || dataType == PIM_INT32 || dataType == PIM_INT64);
-      bool isUnsigned = (dataType == PIM_UINT8 || dataType == PIM_UINT16 || dataType == PIM_UINT32 || dataType == PIM_UINT64);
-      bool isFP = (dataType == PIM_FP32);
-      if (isSigned) {
-        int64_t signedOperand = objSrc.getElementBits(elemIdx);
-        int64_t result = 0;
-        if(!computeResult(signedOperand, m_cmdType, (int64_t)m_scalarValue, result, bitsPerElementSrc)) return false;
-        objDest.setElement(elemIdx, result);
-      } else if (isUnsigned) {
-        uint64_t unsignedOperand = objSrc.getElementBits(elemIdx);
-        uint64_t result = 0;
-        if(!computeResult(unsignedOperand, m_cmdType, m_scalarValue, result, bitsPerElementSrc)) return false;
-        objDest.setElement(elemIdx, result);
-      } else if (isFP){
-        uint64_t bits = objSrc.getElementBits(elemIdx);
-        float floatOperand = pimUtils::castBitsToType<float>(bits);
-        float result = 0.0;
-        if(!computeResultFP(floatOperand, m_cmdType, pimUtils::castBitsToType<float>(m_scalarValue), result)) return false;
-        objDest.setElement(elemIdx, result);
-      } else {
-      assert(0); // todo: data type
-      }
+    bool isSigned = (dataType == PIM_INT8 || dataType == PIM_INT16 || dataType == PIM_INT32 || dataType == PIM_INT64);
+    bool isUnsigned = (dataType == PIM_UINT8 || dataType == PIM_UINT16 || dataType == PIM_UINT32 || dataType == PIM_UINT64);
+    bool isFP = (dataType == PIM_FP32);
+    if (isSigned) {
+      int64_t signedOperand = objSrc.getElementBits(elemIdx);
+      int64_t result = 0;
+      if(!computeResult(signedOperand, m_cmdType, (int64_t)m_scalarValue, result, bitsPerElementSrc)) return false;
+      objDest.setElement(elemIdx, result);
+    } else if (isUnsigned) {
+      uint64_t unsignedOperand = objSrc.getElementBits(elemIdx);
+      uint64_t result = 0;
+      if(!computeResult(unsignedOperand, m_cmdType, m_scalarValue, result, bitsPerElementSrc)) return false;
+      objDest.setElement(elemIdx, result);
+    } else if (isFP){
+      uint64_t bits = objSrc.getElementBits(elemIdx);
+      float floatOperand = pimUtils::castBitsToType<float>(bits);
+      float result = 0.0;
+      if(!computeResultFP(floatOperand, m_cmdType, pimUtils::castBitsToType<float>(m_scalarValue), result)) return false;
+      objDest.setElement(elemIdx, result);
+    } else {
+    assert(0); // todo: data type
     }
   }
   return true;
@@ -495,35 +493,33 @@ pimCmdFunc2::computeRegion(unsigned index)
   unsigned numElementsInRegion = src1Region.getNumElemInRegion();
   for (unsigned j = 0; j < numElementsInRegion; ++j) {
     uint64_t elemIdx = elemIdxBegin + j;
-    if (dataType == PIM_INT8 || dataType == PIM_INT16 || dataType == PIM_INT32 || dataType == PIM_INT64 || dataType == PIM_UINT8 || dataType == PIM_UINT16 || dataType == PIM_UINT32 || dataType == PIM_UINT64 || dataType == PIM_FP32) {
-      bool isSigned = (dataType == PIM_INT8 || dataType == PIM_INT16 || dataType == PIM_INT32 || dataType == PIM_INT64);
-      bool isUnsigned = (dataType == PIM_UINT8 || dataType == PIM_UINT16 || dataType == PIM_UINT32 || dataType == PIM_UINT64);
-      bool isFP = (dataType == PIM_FP32);
-      if (isSigned) {
-        uint64_t operandBits1 = objSrc1.getElementBits(elemIdx);
-        uint64_t operandBits2 = objSrc2.getElementBits(elemIdx);
-        int64_t operand1 = pimUtils::signExt(operandBits1, dataType);
-        int64_t operand2 = pimUtils::signExt(operandBits2, dataType);
-        int64_t result = 0;
-        if(!computeResult(operand1, operand2, m_cmdType, (int64_t)m_scalarValue, result)) return false;
-        objDest.setElement(elemIdx, result);
-      } else if (isUnsigned) {
-        uint64_t unsignedOperand1 = objSrc1.getElementBits(elemIdx);
-        uint64_t unsignedOperand2 = objSrc2.getElementBits(elemIdx);
-        uint64_t result = 0;
-        if(!computeResult(unsignedOperand1, unsignedOperand2, m_cmdType, m_scalarValue, result)) return false;
-        objDest.setElement(elemIdx, result);
-      } else if (isFP){
-        uint64_t operandBits1 = objSrc1.getElementBits(elemIdx);
-        uint64_t operandBits2 = objSrc2.getElementBits(elemIdx);
-        float floatOperand1 = pimUtils::castBitsToType<float>(operandBits1);
-        float floatOperand2 = pimUtils::castBitsToType<float>(operandBits2);
-        float result = 0.0;
-        if(!computeResultFP(floatOperand1, floatOperand2, m_cmdType, pimUtils::castBitsToType<float>(m_scalarValue), result)) return false;
-        objDest.setElement(elemIdx, result);
-      } else {
-      assert(0); // todo: data type
-      }
+    bool isSigned = (dataType == PIM_INT8 || dataType == PIM_INT16 || dataType == PIM_INT32 || dataType == PIM_INT64);
+    bool isUnsigned = (dataType == PIM_UINT8 || dataType == PIM_UINT16 || dataType == PIM_UINT32 || dataType == PIM_UINT64);
+    bool isFP = (dataType == PIM_FP32);
+    if (isSigned) {
+      uint64_t operandBits1 = objSrc1.getElementBits(elemIdx);
+      uint64_t operandBits2 = objSrc2.getElementBits(elemIdx);
+      int64_t operand1 = pimUtils::signExt(operandBits1, dataType);
+      int64_t operand2 = pimUtils::signExt(operandBits2, dataType);
+      int64_t result = 0;
+      if(!computeResult(operand1, operand2, m_cmdType, (int64_t)m_scalarValue, result)) return false;
+      objDest.setElement(elemIdx, result);
+    } else if (isUnsigned) {
+      uint64_t unsignedOperand1 = objSrc1.getElementBits(elemIdx);
+      uint64_t unsignedOperand2 = objSrc2.getElementBits(elemIdx);
+      uint64_t result = 0;
+      if(!computeResult(unsignedOperand1, unsignedOperand2, m_cmdType, m_scalarValue, result)) return false;
+      objDest.setElement(elemIdx, result);
+    } else if (isFP){
+      uint64_t operandBits1 = objSrc1.getElementBits(elemIdx);
+      uint64_t operandBits2 = objSrc2.getElementBits(elemIdx);
+      float floatOperand1 = pimUtils::castBitsToType<float>(operandBits1);
+      float floatOperand2 = pimUtils::castBitsToType<float>(operandBits2);
+      float result = 0.0;
+      if(!computeResultFP(floatOperand1, floatOperand2, m_cmdType, pimUtils::castBitsToType<float>(m_scalarValue), result)) return false;
+      objDest.setElement(elemIdx, result);
+    } else {
+    assert(0); // todo: data type
     }
   }
   return true;

--- a/libpimeval/src/pimCmd.cpp
+++ b/libpimeval/src/pimCmd.cpp
@@ -601,7 +601,7 @@ pimCmdRedSum<T>::computeRegion(unsigned index)
       if (!isFP) {
         T integerOperand = pimUtils::signExt(operandBits, dataType);
         m_regionSum[index] += integerOperand;
-      } else if (isFP){
+      } else if (isFP) {
         float floatOperand = pimUtils::castBitsToType<float>(operandBits);
         m_regionSum[index] += floatOperand;
       } else {

--- a/libpimeval/src/pimCmd.cpp
+++ b/libpimeval/src/pimCmd.cpp
@@ -590,14 +590,23 @@ pimCmdRedSum<T>::computeRegion(unsigned index)
 {
   const pimObjInfo& objSrc = m_device->getResMgr()->getObjInfo(m_src);
   const pimRegion& srcRegion = objSrc.getRegions()[index];
+  PimDataType dataType = objSrc.getDataType();
 
   unsigned numElementsInRegion = srcRegion.getNumElemInRegion();
   uint64_t currIdx = srcRegion.getElemIdxBegin();
   for (unsigned j = 0; j < numElementsInRegion && currIdx < m_idxEnd; ++j) {
     if (currIdx >= m_idxBegin) {
       uint64_t operandBits = objSrc.getElementBits(currIdx);
-      T operand = pimUtils::signExt(operandBits, objSrc.getDataType()); // How do we incorporate FP32 in here?
-      m_regionSum[index] += operand;
+      bool isFloat = (dataType == PIM_FP32);
+      if(!isFloat){
+        T integerOperand = pimUtils::signExt(operandBits, dataType);
+        m_regionSum[index] += integerOperand;
+      } else if (isFloat){
+        float floatOperand = pimUtils::castBitsToType<float>(operandBits);
+        m_regionSum[index] += floatOperand;
+      } else {
+        assert(0); // todo: data type
+      }
     }
     currIdx += 1;
   }

--- a/libpimeval/src/pimCmd.h
+++ b/libpimeval/src/pimCmd.h
@@ -253,7 +253,7 @@ private:
   }
 
   template<typename T>
-  inline bool computeResultFP(T operand, PimCmdEnum cmdType, T scalerValue, T& result, int bitsPerElementSrc) {
+  inline bool computeResultFP(T operand, PimCmdEnum cmdType, T scalerValue, T& result) {
     result = operand;
     switch (cmdType) {
     case PimCmdEnum::ADD_SCALAR: result += scalerValue; break;
@@ -316,6 +316,68 @@ protected:
   PimObjId m_src2;
   PimObjId m_dest;
   uint64_t m_scalarValue;
+private:
+  template<typename T>
+  inline bool computeResult(T operand1, T operand2, PimCmdEnum cmdType, T scalarValue, T& result) {
+    switch (cmdType) {
+    case PimCmdEnum::ADD: result = operand1 + operand2; break;
+    case PimCmdEnum::SUB: result = operand1 - operand2; break;
+    case PimCmdEnum::MUL: result = operand1 * operand2; break;
+    case PimCmdEnum::DIV:
+        if (operand2 == 0) {
+            std::printf("PIM-Error: Division by zero\n");
+            return false;
+        }
+        result = operand1 / operand2;
+        break;
+    case PimCmdEnum::AND: result = operand1 & operand2; break;
+    case PimCmdEnum::OR: result = operand1 | operand2; break;
+    case PimCmdEnum::XOR: result = operand1 ^ operand2; break;
+    case PimCmdEnum::XNOR: result = ~(operand1 ^ operand2); break;
+    case PimCmdEnum::GT: result = operand1 > operand2 ? 1 : 0; break;
+    case PimCmdEnum::LT: result = operand1 < operand2 ? 1 : 0; break;
+    case PimCmdEnum::EQ: result = operand1 == operand2 ? 1 : 0; break;
+    case PimCmdEnum::MIN: result = (operand1 < operand2) ? operand1 : operand2; break;
+    case PimCmdEnum::MAX: result = (operand1 > operand2) ? operand1 : operand2; break;
+    case PimCmdEnum::SCALED_ADD: result = (operand1 * scalarValue) + operand2; break;
+    default:
+        std::printf("PIM-Error: Unexpected cmd type %d\n", static_cast<int>(m_cmdType));
+          assert(0);
+    }
+    return true;
+  }
+
+  template<typename T>
+  inline bool computeResultFP(T operand1, T operand2, PimCmdEnum cmdType, T scalarValue, T& result) {
+    switch (cmdType) {
+    case PimCmdEnum::ADD: result = operand1 + operand2; break;
+    case PimCmdEnum::SUB: result = operand1 - operand2; break;
+    case PimCmdEnum::MUL: result = operand1 * operand2; break;
+    case PimCmdEnum::DIV:
+        if (operand2 == 0) {
+            std::printf("PIM-Error: Division by zero\n");
+            return false;
+        }
+        result = operand1 / operand2;
+        break;
+    case PimCmdEnum::GT: result = operand1 > operand2 ? 1 : 0; break;
+    case PimCmdEnum::LT: result = operand1 < operand2 ? 1 : 0; break;
+    case PimCmdEnum::EQ: result = operand1 == operand2 ? 1 : 0; break;
+    case PimCmdEnum::MIN: result = (operand1 < operand2) ? operand1 : operand2; break;
+    case PimCmdEnum::MAX: result = (operand1 > operand2) ? operand1 : operand2; break;
+    case PimCmdEnum::SCALED_ADD: result = (operand1 * scalarValue) + operand2; break;
+    case PimCmdEnum::AND:
+    case PimCmdEnum::OR:
+    case PimCmdEnum::XOR:
+    case PimCmdEnum::XNOR:
+        std::printf("PIM-Error: Cannot perform bitwise operation on floating point values.\n");
+        return false;
+    default:
+        std::printf("PIM-Error: Unexpected cmd type %d\n", static_cast<int>(m_cmdType));
+          assert(0);
+    }
+    return true;
+  }
 };
 
 //! @class  pimCmdedSum

--- a/libpimeval/src/pimPerfEnergyBitSerial.cpp
+++ b/libpimeval/src/pimPerfEnergyBitSerial.cpp
@@ -161,6 +161,10 @@ pimPerfEnergyBitSerial::getPerfEnergyForRedSum(PimCmdEnum cmdType, const pimObjI
         msRuntime += aggregateMs;
         mjEnergy += aggregateMs * cpuTDP;
         mjEnergy += m_pBChip * m_numChipsPerRank * m_numRanks * msRuntime;
+      } else if (dataType == PIM_FP32) {
+        std::cout << "PIM-Warning: Perf energy model for FP32 reduction sum on bit-serial PIM is not available yet." << std::endl;
+        msRuntime = 999999999.9; // todo
+        mjEnergy = 999999999.9; // todo
       } else {
         assert(0);
       }

--- a/libpimeval/src/pimSim.cpp
+++ b/libpimeval/src/pimSim.cpp
@@ -1044,7 +1044,9 @@ template bool pimSim::pimBroadcast<float>(PimObjId dest, float value);
 
 template bool pimSim::pimRedSum<uint64_t>(PimObjId src, uint64_t* sum);
 template bool pimSim::pimRedSum<int64_t>(PimObjId src, int64_t* sum);
+template bool pimSim::pimRedSum<float>(PimObjId src, float* sum);
 
 template bool pimSim::pimRedSumRanged<uint64_t>(PimObjId src, uint64_t idxBegin, uint64_t idxEnd, uint64_t* sum);
 template bool pimSim::pimRedSumRanged<int64_t>(PimObjId src, uint64_t idxBegin, uint64_t idxEnd, int64_t* sum);
+template bool pimSim::pimRedSumRanged<float>(PimObjId src, uint64_t idxBegin, uint64_t idxEnd, float* sum);
 

--- a/tests/test-functional/result-golden.txt
+++ b/tests/test-functional/result-golden.txt
@@ -855,44 +855,38 @@ INFO: PIMeval Functional Tests for FP32
 [PASS] FP32 pimSub
 [PASS] FP32 pimMul
 [PASS] FP32 pimDiv
-PIM-Warning: Perf energy model not available for PIM command rotate_elem_r
-[PASS] FP32 pimRotateElementsRight
-PIM-Warning: Perf energy model not available for PIM command rotate_elem_l
-[PASS] FP32 pimRotateElementsLeft
-PIM-Warning: Perf energy model not available for PIM command shift_elem_r
-[PASS] FP32 pimShiftElementsRight
-PIM-Warning: Perf energy model not available for PIM command shift_elem_l
-[PASS] FP32 pimShiftElementsLeft
-----------------------------------------
-PIM Params:
-           PIM Device Type Enum : PIM_FUNCTIONAL
-          PIM Simulation Target : PIM_DEVICE_BITSIMD_V_AP
- Rank, Bank, Subarray, Row, Col : 1, 1, 4, 1024, 256
-            Number of PIM Cores : 2
-        Number of Rows per Core : 2048
-        Number of Cols per Core : 256
-                Typical Rank BW : 25.600000 GB/s
-                  Row Read (ns) : 28.500000
-                 Row Write (ns) : 43.500000
-                      tCCD (ns) : 3.000000
-Data Copy Stats:
-                               Host to Device : 48000 bytes
-                               Device to Host : 128000 bytes
-                             Device to Device : 64000 bytes
-                              TOTAL --------- : 176000 bytes       0.218279 ms Estimated Runtime       0.339844 mj Estimated Energy
-PIM Command Stats:
-                                      PIM-CMD :        CNT EstimatedRuntime(ms) EstimatedEnergyConsumption(mJ)
-                                   add.fp32.v :          1       0.698748       0.449430
-                                   div.fp32.v :          1       1.479804       0.951414
-                                   mul.fp32.v :          1       1.012152       0.650623
-                         rotate_elem_l.fp32.v :          1       0.020741       0.000088
-                         rotate_elem_r.fp32.v :          1       0.020741       0.000088
-                          shift_elem_l.fp32.v :          1       0.020741       0.000088
-                          shift_elem_r.fp32.v :          1       0.020741       0.000088
-                                   sub.fp32.v :          1       0.698748       0.449430
-                              TOTAL --------- :          8       3.972415       2.501247
-----------------------------------------
-Result: COMPLETED
+PIM-Warning: Unimplemented bit-serial runtime estimation for device=PIM_DEVICE_BITSIMD_V_AP cmd=abs dataType=fp32
+[PASS] FP32 pimAbs
+PIM-Warning: Unimplemented bit-serial runtime estimation for device=PIM_DEVICE_BITSIMD_V_AP cmd=gt dataType=fp32
+[PASS] FP32 pimGT
+PIM-Warning: Unimplemented bit-serial runtime estimation for device=PIM_DEVICE_BITSIMD_V_AP cmd=lt dataType=fp32
+[PASS] FP32 pimLT
+PIM-Warning: Unimplemented bit-serial runtime estimation for device=PIM_DEVICE_BITSIMD_V_AP cmd=eq dataType=fp32
+[PASS] FP32 pimEQ
+PIM-Warning: Unimplemented bit-serial runtime estimation for device=PIM_DEVICE_BITSIMD_V_AP cmd=min dataType=fp32
+[PASS] FP32 pimMin
+PIM-Warning: Unimplemented bit-serial runtime estimation for device=PIM_DEVICE_BITSIMD_V_AP cmd=max dataType=fp32
+[PASS] FP32 pimMax
+PIM-Warning: Unimplemented bit-serial runtime estimation for device=PIM_DEVICE_BITSIMD_V_AP cmd=add_scalar dataType=fp32
+[PASS] FP32 pimAddScalar
+PIM-Warning: Unimplemented bit-serial runtime estimation for device=PIM_DEVICE_BITSIMD_V_AP cmd=sub_scalar dataType=fp32
+[PASS] FP32 pimSubScalar
+[PASS] FP32 pimMulScalar
+PIM-Warning: Unimplemented bit-serial runtime estimation for device=PIM_DEVICE_BITSIMD_V_AP cmd=div_scalar dataType=fp32
+[PASS] FP32 pimDivScalar
+PIM-Warning: Unimplemented bit-serial runtime estimation for device=PIM_DEVICE_BITSIMD_V_AP cmd=gt_scalar dataType=fp32
+[PASS] FP32 pimGTScalar
+PIM-Warning: Unimplemented bit-serial runtime estimation for device=PIM_DEVICE_BITSIMD_V_AP cmd=lt_scalar dataType=fp32
+[PASS] FP32 pimLTScalar
+PIM-Warning: Unimplemented bit-serial runtime estimation for device=PIM_DEVICE_BITSIMD_V_AP cmd=eq_scalar dataType=fp32
+[PASS] FP32 pimEQScalar
+PIM-Warning: Unimplemented bit-serial runtime estimation for device=PIM_DEVICE_BITSIMD_V_AP cmd=min_scalar dataType=fp32
+[PASS] FP32 pimMinScalar
+PIM-Warning: Unimplemented bit-serial runtime estimation for device=PIM_DEVICE_BITSIMD_V_AP cmd=max_scalar dataType=fp32
+[PASS] FP32 pimMaxScalar
+PIM-Warning: Unimplemented bit-serial runtime estimation for device=PIM_DEVICE_BITSIMD_V_AP cmd=scaled_add dataType=fp32
+[PASS] FP32 pimScaledAdd
+test-functional.out: src/pimPerfEnergyBitSerial.cpp:165: virtual pimeval::perfEnergy pimPerfEnergyBitSerial::getPerfEnergyForRedSum(PimCmdEnum, const pimObjInfo&, unsigned int) const: Assertion `0' failed.
 PIMeval Functional Testing
 PIM-Info: Trying to read simulation target from envirnment variable PIMEVAL_TARGET
 PIM-Info: Current Device = PIM_FUNCTIONAL, Simulation Target = PIM_DEVICE_FULCRUM
@@ -1732,6 +1726,23 @@ INFO: PIMeval Functional Tests for FP32
 [PASS] FP32 pimSub
 [PASS] FP32 pimMul
 [PASS] FP32 pimDiv
+[PASS] FP32 pimAbs
+[PASS] FP32 pimGT
+[PASS] FP32 pimLT
+[PASS] FP32 pimEQ
+[PASS] FP32 pimMin
+[PASS] FP32 pimMax
+[PASS] FP32 pimAddScalar
+[PASS] FP32 pimSubScalar
+[PASS] FP32 pimMulScalar
+[PASS] FP32 pimDivScalar
+[PASS] FP32 pimGTScalar
+[PASS] FP32 pimLTScalar
+[PASS] FP32 pimEQScalar
+[PASS] FP32 pimMinScalar
+[PASS] FP32 pimMaxScalar
+[PASS] FP32 pimScaledAdd
+[PASS] FP32 pimBroadcastFP32
 PIM-Warning: Perf energy model not available for PIM command rotate_elem_r
 [PASS] FP32 pimRotateElementsRight
 PIM-Warning: Perf energy model not available for PIM command rotate_elem_l
@@ -1754,20 +1765,39 @@ PIM Params:
                       tCCD (ns) : 3.000000
 Data Copy Stats:
                                Host to Device : 48000 bytes
-                               Device to Host : 128000 bytes
+                               Device to Host : 432000 bytes
                              Device to Device : 64000 bytes
-                              TOTAL --------- : 176000 bytes       0.218279 ms Estimated Runtime       0.339844 mj Estimated Energy
+                              TOTAL --------- : 480000 bytes       0.229338 ms Estimated Runtime       0.357893 mj Estimated Energy
 PIM Command Stats:
                                       PIM-CMD :        CNT EstimatedRuntime(ms) EstimatedEnergyConsumption(mJ)
+                                   abs.fp32.h :          1       0.012252       0.008042
                                    add.fp32.h :          1       0.037305       0.023872
+                            add_scalar.fp32.h :          1       0.012252       0.008042
+                             broadcast.fp32.h :          1       0.023055       0.014584
                                    div.fp32.h :          1       0.037305       0.023872
+                            div_scalar.fp32.h :          1       0.012252       0.008042
+                                    eq.fp32.h :          1       0.037305       0.023366
+                             eq_scalar.fp32.h :          1       0.012252       0.008040
+                                    gt.fp32.h :          1       0.037305       0.023366
+                             gt_scalar.fp32.h :          1       0.012252       0.008040
+                                    lt.fp32.h :          1       0.037305       0.023366
+                             lt_scalar.fp32.h :          1       0.012252       0.008040
+                                   max.fp32.h :          1       0.037305       0.023366
+                            max_scalar.fp32.h :          1       0.012252       0.008040
+                                   min.fp32.h :          1       0.037305       0.023366
+                            min_scalar.fp32.h :          1       0.012252       0.008040
                                    mul.fp32.h :          1       0.037305       0.023872
+                            mul_scalar.fp32.h :          1       0.012252       0.008042
+                                redsum.fp32.h :          1       0.012209       0.007745
+                          redsum_range.fp32.h :          1       0.008214       0.005252
                          rotate_elem_l.fp32.h :          1       0.043646       0.000086
                          rotate_elem_r.fp32.h :          1       0.043646       0.000086
+                            scaled_add.fp32.h :          1       0.024432       0.015839
                           shift_elem_l.fp32.h :          1       0.043646       0.000086
                           shift_elem_r.fp32.h :          1       0.043646       0.000086
                                    sub.fp32.h :          1       0.037305       0.023872
-                              TOTAL --------- :          8       0.323802       0.095831
+                            sub_scalar.fp32.h :          1       0.012252       0.008042
+                              TOTAL --------- :         27       0.700757       0.336492
 ----------------------------------------
 Result: COMPLETED
 PIMeval Functional Testing
@@ -2074,7 +2104,7 @@ PIM Command Stats:
                          redsum_range.int16.h :          2       0.006806       0.007915
                         rotate_elem_l.int16.h :          1       0.031536       0.000086
                         rotate_elem_r.int16.h :          1       0.031536       0.000086
-                           scaled_add.int16.h :          1       0.035153       0.029843
+                           scaled_add.int16.h :          1       0.035154       0.029843
                          shift_bits_l.int16.h :          1       0.005129       0.008472
                          shift_bits_r.int16.h :          1       0.005129       0.008472
                          shift_elem_l.int16.h :          1       0.031536       0.000086
@@ -2177,7 +2207,7 @@ PIM Command Stats:
                         redsum_range.uint16.h :          2       0.006806       0.007915
                        rotate_elem_l.uint16.h :          1       0.031536       0.000086
                        rotate_elem_r.uint16.h :          1       0.031536       0.000086
-                          scaled_add.uint16.h :          1       0.035153       0.029843
+                          scaled_add.uint16.h :          1       0.035154       0.029843
                         shift_bits_l.uint16.h :          1       0.005129       0.008472
                         shift_bits_r.uint16.h :          1       0.005129       0.008472
                         shift_elem_l.uint16.h :          1       0.031536       0.000086
@@ -2280,7 +2310,7 @@ PIM Command Stats:
                          redsum_range.int32.h :          2       0.013486       0.015605
                         rotate_elem_l.int32.h :          1       0.087146       0.000171
                         rotate_elem_r.int32.h :          1       0.087146       0.000171
-                           scaled_add.int32.h :          1       0.070278       0.059669
+                           scaled_add.int32.h :          1       0.070279       0.059669
                          shift_bits_l.int32.h :          1       0.010129       0.016863
                          shift_bits_r.int32.h :          1       0.010129       0.016863
                          shift_elem_l.int32.h :          1       0.087146       0.000171
@@ -2383,7 +2413,7 @@ PIM Command Stats:
                         redsum_range.uint32.h :          2       0.013486       0.015605
                        rotate_elem_l.uint32.h :          1       0.087146       0.000171
                        rotate_elem_r.uint32.h :          1       0.087146       0.000171
-                          scaled_add.uint32.h :          1       0.070278       0.059669
+                          scaled_add.uint32.h :          1       0.070279       0.059669
                         shift_bits_l.uint32.h :          1       0.010129       0.016863
                         shift_bits_r.uint32.h :          1       0.010129       0.016863
                         shift_elem_l.uint32.h :          1       0.087146       0.000171
@@ -2609,6 +2639,23 @@ INFO: PIMeval Functional Tests for FP32
 [PASS] FP32 pimSub
 [PASS] FP32 pimMul
 [PASS] FP32 pimDiv
+[PASS] FP32 pimAbs
+[PASS] FP32 pimGT
+[PASS] FP32 pimLT
+[PASS] FP32 pimEQ
+[PASS] FP32 pimMin
+[PASS] FP32 pimMax
+[PASS] FP32 pimAddScalar
+[PASS] FP32 pimSubScalar
+[PASS] FP32 pimMulScalar
+[PASS] FP32 pimDivScalar
+[PASS] FP32 pimGTScalar
+[PASS] FP32 pimLTScalar
+[PASS] FP32 pimEQScalar
+[PASS] FP32 pimMinScalar
+[PASS] FP32 pimMaxScalar
+[PASS] FP32 pimScaledAdd
+[PASS] FP32 pimBroadcastFP32
 PIM-Warning: Perf energy model not available for PIM command rotate_elem_r
 [PASS] FP32 pimRotateElementsRight
 PIM-Warning: Perf energy model not available for PIM command rotate_elem_l
@@ -2631,19 +2678,38 @@ PIM Params:
                       tCCD (ns) : 3.000000
 Data Copy Stats:
                                Host to Device : 48000 bytes
-                               Device to Host : 128000 bytes
+                               Device to Host : 432000 bytes
                              Device to Device : 64000 bytes
-                              TOTAL --------- : 176000 bytes       0.218279 ms Estimated Runtime       0.339844 mj Estimated Energy
+                              TOTAL --------- : 480000 bytes       0.229338 ms Estimated Runtime       0.357893 mj Estimated Energy
 PIM Command Stats:
                                       PIM-CMD :        CNT EstimatedRuntime(ms) EstimatedEnergyConsumption(mJ)
+                                   abs.fp32.h :          1       0.010129       0.016863
                                    add.fp32.h :          1       0.117250       0.088978
+                            add_scalar.fp32.h :          1       0.010129       0.016863
+                             broadcast.fp32.h :          1       0.010171       0.011618
                                    div.fp32.h :          1       0.117250       0.088978
+                            div_scalar.fp32.h :          1       0.010129       0.016863
+                                    eq.fp32.h :          1       0.117250       0.088977
+                             eq_scalar.fp32.h :          1       0.010129       0.016863
+                                    gt.fp32.h :          1       0.117250       0.088977
+                             gt_scalar.fp32.h :          1       0.010129       0.016863
+                                    lt.fp32.h :          1       0.117250       0.088977
+                             lt_scalar.fp32.h :          1       0.010129       0.016863
+                                   max.fp32.h :          1       0.117250       0.088977
+                            max_scalar.fp32.h :          1       0.010129       0.016863
+                                   min.fp32.h :          1       0.117250       0.088977
+                            min_scalar.fp32.h :          1       0.010129       0.016863
                                    mul.fp32.h :          1       0.117250       0.088978
+                            mul_scalar.fp32.h :          1       0.010129       0.016863
+                                redsum.fp32.h :          1       0.010043       0.011601
+                          redsum_range.fp32.h :          1       0.006743       0.007802
                          rotate_elem_l.fp32.h :          1       0.087146       0.000171
                          rotate_elem_r.fp32.h :          1       0.087146       0.000171
+                            scaled_add.fp32.h :          1       0.070279       0.059669
                           shift_elem_l.fp32.h :          1       0.087146       0.000171
                           shift_elem_r.fp32.h :          1       0.087146       0.000171
                                    sub.fp32.h :          1       0.117250       0.088978
-                              TOTAL --------- :          8       0.817582       0.356597
+                            sub_scalar.fp32.h :          1       0.010129       0.016863
+                              TOTAL --------- :         27       1.602358       1.060802
 ----------------------------------------
 Result: COMPLETED

--- a/tests/test-functional/result-golden.txt
+++ b/tests/test-functional/result-golden.txt
@@ -886,7 +886,66 @@ PIM-Warning: Unimplemented bit-serial runtime estimation for device=PIM_DEVICE_B
 [PASS] FP32 pimMaxScalar
 PIM-Warning: Unimplemented bit-serial runtime estimation for device=PIM_DEVICE_BITSIMD_V_AP cmd=scaled_add dataType=fp32
 [PASS] FP32 pimScaledAdd
-test-functional.out: src/pimPerfEnergyBitSerial.cpp:165: virtual pimeval::perfEnergy pimPerfEnergyBitSerial::getPerfEnergyForRedSum(PimCmdEnum, const pimObjInfo&, unsigned int) const: Assertion `0' failed.
+PIM-Warning: Perf energy model for FP32 reduction sum on bit-serial PIM is not available yet.
+PIM-Warning: Perf energy model for FP32 reduction sum on bit-serial PIM is not available yet.
+[PASS] FP32 pimBroadcastFP32
+PIM-Warning: Perf energy model not available for PIM command rotate_elem_r
+[PASS] FP32 pimRotateElementsRight
+PIM-Warning: Perf energy model not available for PIM command rotate_elem_l
+[PASS] FP32 pimRotateElementsLeft
+PIM-Warning: Perf energy model not available for PIM command shift_elem_r
+[PASS] FP32 pimShiftElementsRight
+PIM-Warning: Perf energy model not available for PIM command shift_elem_l
+[PASS] FP32 pimShiftElementsLeft
+----------------------------------------
+PIM Params:
+           PIM Device Type Enum : PIM_FUNCTIONAL
+          PIM Simulation Target : PIM_DEVICE_BITSIMD_V_AP
+ Rank, Bank, Subarray, Row, Col : 1, 1, 4, 1024, 256
+            Number of PIM Cores : 2
+        Number of Rows per Core : 2048
+        Number of Cols per Core : 256
+                Typical Rank BW : 25.600000 GB/s
+                  Row Read (ns) : 28.500000
+                 Row Write (ns) : 43.500000
+                      tCCD (ns) : 3.000000
+Data Copy Stats:
+                               Host to Device : 48000 bytes
+                               Device to Host : 432000 bytes
+                             Device to Device : 64000 bytes
+                              TOTAL --------- : 480000 bytes       0.229338 ms Estimated Runtime       0.357893 mj Estimated Energy
+PIM Command Stats:
+                                      PIM-CMD :        CNT EstimatedRuntime(ms) EstimatedEnergyConsumption(mJ)
+                                   abs.fp32.v :          1 8000000.000000       0.000000
+                                   add.fp32.v :          1       0.698748       0.449430
+                            add_scalar.fp32.v :          1 8000000.000000       0.000000
+                             broadcast.fp32.v :          1       0.011904       0.007434
+                                   div.fp32.v :          1       1.479804       0.951414
+                            div_scalar.fp32.v :          1 8000000.000000       0.000000
+                                    eq.fp32.v :          1 8000000.000000       0.000000
+                             eq_scalar.fp32.v :          1 8000000.000000       0.000000
+                                    gt.fp32.v :          1 8000000.000000       0.000000
+                             gt_scalar.fp32.v :          1 8000000.000000       0.000000
+                                    lt.fp32.v :          1 8000000.000000       0.000000
+                             lt_scalar.fp32.v :          1 8000000.000000       0.000000
+                                   max.fp32.v :          1 8000000.000000       0.000000
+                            max_scalar.fp32.v :          1 8000000.000000       0.000000
+                                   min.fp32.v :          1 8000000.000000       0.000000
+                            min_scalar.fp32.v :          1 8000000.000000       0.000000
+                                   mul.fp32.v :          1       1.012152       0.650623
+                            mul_scalar.fp32.v :          1       1.012152       0.650623
+                                redsum.fp32.v :          1 999999999.900000 999999999.900000
+                          redsum_range.fp32.v :          1 999999999.900000 999999999.900000
+                         rotate_elem_l.fp32.v :          1       0.020741       0.000088
+                         rotate_elem_r.fp32.v :          1       0.020741       0.000088
+                            scaled_add.fp32.v :          1 8000000.000000       0.000000
+                          shift_elem_l.fp32.v :          1       0.020741       0.000088
+                          shift_elem_r.fp32.v :          1       0.020741       0.000088
+                                   sub.fp32.v :          1       0.698748       0.449430
+                            sub_scalar.fp32.v :          1 8000000.000000       0.000000
+                              TOTAL --------- :         27 2120000004.796471 2000000002.959303
+----------------------------------------
+Result: COMPLETED
 PIMeval Functional Testing
 PIM-Info: Trying to read simulation target from envirnment variable PIMEVAL_TARGET
 PIM-Info: Current Device = PIM_FUNCTIONAL, Simulation Target = PIM_DEVICE_FULCRUM
@@ -2104,7 +2163,7 @@ PIM Command Stats:
                          redsum_range.int16.h :          2       0.006806       0.007915
                         rotate_elem_l.int16.h :          1       0.031536       0.000086
                         rotate_elem_r.int16.h :          1       0.031536       0.000086
-                           scaled_add.int16.h :          1       0.035154       0.029843
+                           scaled_add.int16.h :          1       0.035153       0.029843
                          shift_bits_l.int16.h :          1       0.005129       0.008472
                          shift_bits_r.int16.h :          1       0.005129       0.008472
                          shift_elem_l.int16.h :          1       0.031536       0.000086
@@ -2207,7 +2266,7 @@ PIM Command Stats:
                         redsum_range.uint16.h :          2       0.006806       0.007915
                        rotate_elem_l.uint16.h :          1       0.031536       0.000086
                        rotate_elem_r.uint16.h :          1       0.031536       0.000086
-                          scaled_add.uint16.h :          1       0.035154       0.029843
+                          scaled_add.uint16.h :          1       0.035153       0.029843
                         shift_bits_l.uint16.h :          1       0.005129       0.008472
                         shift_bits_r.uint16.h :          1       0.005129       0.008472
                         shift_elem_l.uint16.h :          1       0.031536       0.000086
@@ -2310,7 +2369,7 @@ PIM Command Stats:
                          redsum_range.int32.h :          2       0.013486       0.015605
                         rotate_elem_l.int32.h :          1       0.087146       0.000171
                         rotate_elem_r.int32.h :          1       0.087146       0.000171
-                           scaled_add.int32.h :          1       0.070279       0.059669
+                           scaled_add.int32.h :          1       0.070278       0.059669
                          shift_bits_l.int32.h :          1       0.010129       0.016863
                          shift_bits_r.int32.h :          1       0.010129       0.016863
                          shift_elem_l.int32.h :          1       0.087146       0.000171
@@ -2413,7 +2472,7 @@ PIM Command Stats:
                         redsum_range.uint32.h :          2       0.013486       0.015605
                        rotate_elem_l.uint32.h :          1       0.087146       0.000171
                        rotate_elem_r.uint32.h :          1       0.087146       0.000171
-                          scaled_add.uint32.h :          1       0.070279       0.059669
+                          scaled_add.uint32.h :          1       0.070278       0.059669
                         shift_bits_l.uint32.h :          1       0.010129       0.016863
                         shift_bits_r.uint32.h :          1       0.010129       0.016863
                         shift_elem_l.uint32.h :          1       0.087146       0.000171
@@ -2705,7 +2764,7 @@ PIM Command Stats:
                           redsum_range.fp32.h :          1       0.006743       0.007802
                          rotate_elem_l.fp32.h :          1       0.087146       0.000171
                          rotate_elem_r.fp32.h :          1       0.087146       0.000171
-                            scaled_add.fp32.h :          1       0.070279       0.059669
+                            scaled_add.fp32.h :          1       0.070278       0.059669
                           shift_elem_l.fp32.h :          1       0.087146       0.000171
                           shift_elem_r.fp32.h :          1       0.087146       0.000171
                                    sub.fp32.h :          1       0.117250       0.088978

--- a/tests/test-functional/test-functional-fp.h
+++ b/tests/test-functional/test-functional-fp.h
@@ -46,7 +46,7 @@ testFunctional::testFp(const std::string& category, PimDataType dataType)
   // Cover scalar value testing
   // PIMeval uses uint64_t to represent bits of scalarValue
   const float scalarValFloat = 123.0f;
-  const uint64_t scalarVal = *reinterpret_cast<const uint64_t*>(&scalarValFloat);
+  const uint64_t scalarVal = *reinterpret_cast<const uint32_t*>(&scalarValFloat);
   const int64_t scalarValInt = -11; // for int broadcasting
   vecSrc1[500] = static_cast<T>(scalarVal); // cover scalar EQ
   vecSrc1[501] = static_cast<T>(scalarVal - 1); // cover scalar LT

--- a/tests/test-functional/test-functional-fp.h
+++ b/tests/test-functional/test-functional-fp.h
@@ -78,20 +78,20 @@ testFunctional::testFp(const std::string& category, PimDataType dataType)
       {  1, "pimSub"                 },
       {  2, "pimMul"                 },
       {  3, "pimDiv"                 },
-      // {  4, "pimAbs"                 }, // TODO
+      {  4, "pimAbs"                 },
       //{  5, "pimAnd"                 }, // not supported
       //{  6, "pimOr"                  }, // not supported
       //{  7, "pimXor"                 }, // not supported
       //{  8, "pimXnor"                }, // not supported
-      //{  9, "pimGT"                  }, // TODO
-      // { 10, "pimLT"                  }, // TODO
-      // { 11, "pimEQ"                  }, // TODO
-      // { 12, "pimMin"                 }, // TODO
-      // { 13, "pimMax"                 }, // TODO
-      // { 14, "pimAddScalar"           }, // TODO
-      // { 15, "pimSubScalar"           }, // TODO
-      // { 16, "pimMulScalar"           }, // TODO
-      //{ 17, "pimDivScalar"           }, // TODO
+      // {  9, "pimGT"                  }, 
+      // { 10, "pimLT"                  },
+      // { 11, "pimEQ"                  },
+      // { 12, "pimMin"                 },
+      // { 13, "pimMax"                 },
+      { 14, "pimAddScalar"           },
+      { 15, "pimSubScalar"           },
+      { 16, "pimMulScalar"           },
+      { 17, "pimDivScalar"           },
       //{ 18, "pimAndScalar"           }, // not supported
       //{ 19, "pimOrScalar"            }, // not supported
       //{ 20, "pimXorScalar"           }, // not supported

--- a/tests/test-functional/test-functional-fp.h
+++ b/tests/test-functional/test-functional-fp.h
@@ -213,7 +213,10 @@ testFunctional::testFp(const std::string& category, PimDataType dataType)
         sumFP32Expected += vecSrc1[i];
       }
       // Allowing a small tolerance here because of multithreaded reduction in pimCmd
-      assert(safeAbs(sumFP32 - sumFP32Expected) < 0.01);
+      if (!fuzzyEqualPercent(sumFP32, sumFP32Expected)) {
+        std::cout << "Large FP reduction sum error: Result: " << sumFP32 << " Expected: " << sumFP32Expected << std::endl;
+        assert(0);
+      }
     } else {
       int numError = 0;
       for (unsigned i = 0; i < numElements; ++i) {

--- a/tests/test-functional/test-functional-fp.h
+++ b/tests/test-functional/test-functional-fp.h
@@ -106,7 +106,7 @@ testFunctional::testFp(const std::string& category, PimDataType dataType)
       //{ 29, "pimRedSumInt"           }, // not supported
       { 30, "pimRedSumFP32"          },
       //{ 31, "pimRedSumRangedInt"     }, // not supported
-      // { 32, "pimRedSumRangedFP32"    },
+      { 32, "pimRedSumRangedFP32"    },
       //{ 33, "pimBroadcastInt"        }, // not supported
       { 34, "pimBroadcastFP32"       },
       { 35, "pimRotateElementsRight" },
@@ -205,7 +205,7 @@ testFunctional::testFp(const std::string& category, PimDataType dataType)
         sumUIntExpected += vecSrc1[i];
       }
       assert(sumUInt == sumUIntExpected);
-    }else if (testName == "pimRedSumFP32" || testName == "pimRedSumRangedFP32") {
+    } else if (testName == "pimRedSumFP32" || testName == "pimRedSumRangedFP32") {
       uint64_t begin = (testName == "pimRedSumFP32" ? 0 : idxBegin);
       uint64_t end = (testName == "pimRedSumFP32" ? numElements : idxEnd);
       float sumFP32Expected = 0.0f;

--- a/tests/test-functional/test-functional-fp.h
+++ b/tests/test-functional/test-functional-fp.h
@@ -170,7 +170,7 @@ testFunctional::testFp(const std::string& category, PimDataType dataType)
       case 29: status = pimRedSumInt            (objSrc1, &sumInt);                     break;
       case 30: status = pimRedSumFP32           (objSrc1, &sumFP32);                    break;
       case 31: status = pimRedSumRangedInt      (objSrc1, idxBegin, idxEnd, &sumInt);   break;
-      //case 32: status = pimRedSumRangedFP32     (objSrc1, idxBegin, idxEnd, &sumUInt);  break;
+      case 32: status = pimRedSumRangedFP32     (objSrc1, idxBegin, idxEnd, &sumFP32);  break;
       case 33: status = pimBroadcastInt         (objDest, scalarValInt);                break;
       case 34: status = pimBroadcastFP32          (objDest, scalarValFloat);            break;
       case 35: status = pimRotateElementsRight  (objDest);                              break;
@@ -264,7 +264,6 @@ testFunctional::testFp(const std::string& category, PimDataType dataType)
           default: assert(0);
         }
         if (vecDest[i] != expected) {
-          // FP32 DIVISION sometimes(in extreme cases where float precision has limit) gives different results that have only very small difference compared to the number itself.
           if (numError < maxErrorToShow) {
           std::cout << "Error: Index = " << i << " Result = " << std::fixed << std::setprecision(12) << vecDest[i] << " Expected = " << std::fixed << std::setprecision(12) << expected << std::endl;
           }

--- a/tests/test-functional/test-functional-fp.h
+++ b/tests/test-functional/test-functional-fp.h
@@ -45,7 +45,7 @@ testFunctional::testFp(const std::string& category, PimDataType dataType)
 
   // Cover scalar value testing
   // PIMeval uses uint64_t to represent bits of scalarValue
-  const float scalarValFloat = 123.0;
+  const float scalarValFloat = 123.0f;
   const uint64_t scalarVal = *reinterpret_cast<const uint64_t*>(&scalarValFloat);
   const int64_t scalarValInt = -11; // for int broadcasting
   vecSrc1[500] = static_cast<T>(scalarVal); // cover scalar EQ
@@ -83,11 +83,11 @@ testFunctional::testFp(const std::string& category, PimDataType dataType)
       //{  6, "pimOr"                  }, // not supported
       //{  7, "pimXor"                 }, // not supported
       //{  8, "pimXnor"                }, // not supported
-      // {  9, "pimGT"                  }, 
-      // { 10, "pimLT"                  },
-      // { 11, "pimEQ"                  },
-      // { 12, "pimMin"                 },
-      // { 13, "pimMax"                 },
+      {  9, "pimGT"                  }, 
+      { 10, "pimLT"                  },
+      { 11, "pimEQ"                  },
+      { 12, "pimMin"                 },
+      { 13, "pimMax"                 },
       { 14, "pimAddScalar"           },
       { 15, "pimSubScalar"           },
       { 16, "pimMulScalar"           },
@@ -96,19 +96,19 @@ testFunctional::testFp(const std::string& category, PimDataType dataType)
       //{ 19, "pimOrScalar"            }, // not supported
       //{ 20, "pimXorScalar"           }, // not supported
       //{ 21, "pimXnorScalar"          }, // not supported
-      // { 22, "pimGTScalar"            }, // TODO
-      // { 23, "pimLTScalar"            }, // TODO
-      // { 24, "pimEQScalar"            }, // TODO
-      // { 25, "pimMinScalar"           }, // TODO
-      // { 26, "pimMaxScalar"           }, // TODO
-      //{ 27, "pimScaledAdd"           }, // TODO
+      { 22, "pimGTScalar"            },
+      { 23, "pimLTScalar"            },
+      { 24, "pimEQScalar"            },
+      { 25, "pimMinScalar"           },
+      { 26, "pimMaxScalar"           },
+      { 27, "pimScaledAdd"           },
       //{ 28, "pimPopCount"            }, // not supported
-      //{ 29, "pimRedSumInt"           }, // TODO
-      //{ 30, "pimRedSumUInt"          }, // TODO
-      //{ 31, "pimRedSumRangedInt"     }, // TODO
-      //{ 32, "pimRedSumRangedUInt"    }, // TODO
-      //{ 33, "pimBroadcastInt"        }, // TODO
-      //{ 34, "pimBroadcastFP32"       }, // TODO
+      //{ 29, "pimRedSumInt"           }, // not supported
+      { 30, "pimRedSumFP32"          },
+      //{ 31, "pimRedSumRangedInt"     }, // not supported
+      // { 32, "pimRedSumRangedFP32"    },
+      //{ 33, "pimBroadcastInt"        }, // not supported
+      { 34, "pimBroadcastFP32"       },
       { 35, "pimRotateElementsRight" },
       { 36, "pimRotateElementsLeft"  },
       { 37, "pimShiftElementsRight"  },
@@ -136,6 +136,7 @@ testFunctional::testFp(const std::string& category, PimDataType dataType)
 
     int64_t sumInt = 0;
     uint64_t sumUInt = 0;
+    float sumFP32 = 0.0f;
     switch (testId) {
       case  0: status = pimAdd                  (objSrc1, objSrc2, objDest);            break;
       case  1: status = pimSub                  (objSrc1, objSrc2, objDest);            break;
@@ -167,11 +168,11 @@ testFunctional::testFp(const std::string& category, PimDataType dataType)
       case 27: status = pimScaledAdd            (objSrc1, objSrc2, objDest, scalarVal); break;
       case 28: status = pimPopCount             (objSrc1, objDest);                     break;
       case 29: status = pimRedSumInt            (objSrc1, &sumInt);                     break;
-      case 30: status = pimRedSumUInt           (objSrc1, &sumUInt);                    break;
+      case 30: status = pimRedSumFP32           (objSrc1, &sumFP32);                    break;
       case 31: status = pimRedSumRangedInt      (objSrc1, idxBegin, idxEnd, &sumInt);   break;
-      case 32: status = pimRedSumRangedUInt     (objSrc1, idxBegin, idxEnd, &sumUInt);  break;
+      //case 32: status = pimRedSumRangedFP32     (objSrc1, idxBegin, idxEnd, &sumUInt);  break;
       case 33: status = pimBroadcastInt         (objDest, scalarValInt);                break;
-      case 34: status = pimBroadcastFP32          (objDest, scalarVal);                   break;
+      case 34: status = pimBroadcastFP32          (objDest, scalarValFloat);            break;
       case 35: status = pimRotateElementsRight  (objDest);                              break;
       case 36: status = pimRotateElementsLeft   (objDest);                              break;
       case 37: status = pimShiftElementsRight   (objDest);                              break;
@@ -204,6 +205,14 @@ testFunctional::testFp(const std::string& category, PimDataType dataType)
         sumUIntExpected += vecSrc1[i];
       }
       assert(sumUInt == sumUIntExpected);
+    }else if (testName == "pimRedSumFP32" || testName == "pimRedSumRangedFP32") {
+      uint64_t begin = (testName == "pimRedSumFP32" ? 0 : idxBegin);
+      uint64_t end = (testName == "pimRedSumFP32" ? numElements : idxEnd);
+      float sumFP32Expected = 0.0f;
+      for (uint64_t i = begin; i < end; ++i) {
+        sumFP32Expected += vecSrc1[i];
+      }
+      assert(sumFP32 == sumFP32Expected);
     } else {
       int numError = 0;
       for (unsigned i = 0; i < numElements; ++i) {
@@ -241,9 +250,9 @@ testFunctional::testFp(const std::string& category, PimDataType dataType)
           case 27: expected = (vecSrc1[i] * val) + vecSrc2[i];      break; // pimScaledAdd
           case 28: expected = std::bitset<sizeof(T) * 8>(vecSrc1[i]).count(); break; // pimPopCount
           case 29: assert(0); break; // pimRedSumInt
-          case 30: assert(0); break; // pimRedSumUInt
+          case 30: assert(0); break; // pimRedSumFP32
           case 31: assert(0); break; // pimRedSumRangedInt
-          case 32: assert(0); break; // pimRedSumRangedUInt
+          case 32: assert(0); break; // pimRedSumRangedFP32
           case 33: expected = valInt; break; // pimBroadcastInt
           case 34: expected = val;    break; // pimBroadcastFP32
           case 35: expected = (i == 0 ? vecSrc1.back() : vecSrc1[i - 1]);                break; // pimRotateElementsRight

--- a/tests/test-functional/test-functional-fp.h
+++ b/tests/test-functional/test-functional-fp.h
@@ -212,7 +212,8 @@ testFunctional::testFp(const std::string& category, PimDataType dataType)
       for (uint64_t i = begin; i < end; ++i) {
         sumFP32Expected += vecSrc1[i];
       }
-      assert(sumFP32 == sumFP32Expected);
+      // Allowing a small tolerance here because of multithreaded reduction in pimCmd
+      assert(safeAbs(sumFP32 - sumFP32Expected) < 0.01);
     } else {
       int numError = 0;
       for (unsigned i = 0; i < numElements; ++i) {

--- a/tests/test-functional/test-functional.h
+++ b/tests/test-functional/test-functional.h
@@ -88,5 +88,15 @@ testFunctional::safeAbs(T value)
   return val;
 }
 
+//! @brief  Check if two FP values are fuzzy equal within a percentage tolerance
+template <typename T>
+bool fuzzyEqualPercent(T a, T b, T tolerancePercent = 1e-3) {
+  if (a == 0 || b == 0) {
+    return std::abs(a - b) <= tolerancePercent / 100.0;
+  }
+  T percentDiff = (std::abs(a - b) / std::max(std::abs(a), std::abs(b))) * 100;
+  return percentDiff <= tolerancePercent;
+}
+
 #endif
 


### PR DESCRIPTION
FP32 functional support completed, requesting a merge to the main.

Changes in this commit:

- Fixed the divscalar results inconsistent issue by changing -Ofast to -O3.
- Added FP32 support for all operations.
- Code cleaning up in pimCmdFunc2 (Replacing the big if-else block with a templete function).
