### PR TITLE
Support PIMeval analysis mode for fast performance and energy analysis

### DIFF
--- a/libpimeval/src/libpimeval.cpp
+++ b/libpimeval/src/libpimeval.cpp
@@ -55,6 +55,13 @@ pimResetStats()
   pimSim::get()->resetStats();
 }
 
+//! @brief  Is analysis mode. Call this after device creation
+bool
+pimIsAnalysisMode()
+{
+  return pimSim::get()->isAnalysisMode();
+}
+
 //! @brief  Allocate a PIM resource
 PimObjId
 pimAlloc(PimAllocEnum allocType, uint64_t numElements, PimDataType dataType)

--- a/libpimeval/src/libpimeval.h
+++ b/libpimeval/src/libpimeval.h
@@ -92,13 +92,16 @@ struct PimDeviceProperties {
 typedef int PimCoreId;
 typedef int PimObjId;
 
+// PIMeval simulation
+void pimShowStats();
+void pimResetStats();
+bool pimIsAnalysisMode();
+
 // Device creation and deletion
 PimStatus pimCreateDevice(PimDeviceEnum deviceType, unsigned numRanks, unsigned numBankPerRank, unsigned numSubarrayPerBank, unsigned numRows, unsigned numCols);
 PimStatus pimCreateDeviceFromConfig(PimDeviceEnum deviceType, const char* configFileName);
 PimStatus pimGetDeviceProperties(PimDeviceProperties* deviceProperties);
 PimStatus pimDeleteDevice();
-void pimShowStats();
-void pimResetStats();
 
 // Resource allocation and deletion
 PimObjId pimAlloc(PimAllocEnum allocType, uint64_t numElements, PimDataType dataType);

--- a/libpimeval/src/pimCmd.cpp
+++ b/libpimeval/src/pimCmd.cpp
@@ -134,6 +134,10 @@ pimCmd::isConvertibleType(const pimObjInfo& src, const pimObjInfo& dest) const
 bool
 pimCmd::computeAllRegions(unsigned numRegions)
 {
+  // skip PIM computation in analysis mode
+  if (pimSim::get()->isAnalysisMode()) {
+    return true;
+  }
   if (pimSim::get()->getNumThreads() > 1) { // MT
     std::vector<pimUtils::threadWorker*> workers;
     for (unsigned i = 0; i < numRegions; ++i) {

--- a/libpimeval/src/pimCmd.cpp
+++ b/libpimeval/src/pimCmd.cpp
@@ -172,18 +172,20 @@ pimCmdCopy::execute()
     }
   }
 
-  if (m_cmdType == PimCmdEnum::COPY_H2D) {
-    pimObjInfo &objDest = m_device->getResMgr()->getObjInfo(m_dest);
-    objDest.copyFromHost(m_ptr, m_idxBegin, m_idxEnd);
-  } else if (m_cmdType == PimCmdEnum::COPY_D2H) {
-    const pimObjInfo &objSrc = m_device->getResMgr()->getObjInfo(m_src);
-    objSrc.copyToHost(m_ptr, m_idxBegin, m_idxEnd);
-  } else if (m_cmdType == PimCmdEnum::COPY_D2D) {
-    const pimObjInfo &objSrc = m_device->getResMgr()->getObjInfo(m_src);
-    pimObjInfo &objDest = m_device->getResMgr()->getObjInfo(m_dest);
-    objSrc.copyToObj(objDest, m_idxBegin, m_idxEnd);
-  } else {
-    assert(0);
+  if (!pimSim::get()->isAnalysisMode()) {
+    if (m_cmdType == PimCmdEnum::COPY_H2D) {
+      pimObjInfo &objDest = m_device->getResMgr()->getObjInfo(m_dest);
+      objDest.copyFromHost(m_ptr, m_idxBegin, m_idxEnd);
+    } else if (m_cmdType == PimCmdEnum::COPY_D2H) {
+      const pimObjInfo &objSrc = m_device->getResMgr()->getObjInfo(m_src);
+      objSrc.copyToHost(m_ptr, m_idxBegin, m_idxEnd);
+    } else if (m_cmdType == PimCmdEnum::COPY_D2D) {
+      const pimObjInfo &objSrc = m_device->getResMgr()->getObjInfo(m_src);
+      pimObjInfo &objDest = m_device->getResMgr()->getObjInfo(m_dest);
+      objSrc.copyToObj(objDest, m_idxBegin, m_idxEnd);
+    } else {
+      assert(0);
+    }
   }
 
   // for non-functional simulation, sync dest data to simulated memory

--- a/libpimeval/src/pimDevice.cpp
+++ b/libpimeval/src/pimDevice.cpp
@@ -148,9 +148,9 @@ pimDevice::init(PimDeviceEnum deviceType, unsigned numRanks, unsigned numBankPer
   m_deviceType = deviceType;
   m_simTarget = deviceType;
   if (deviceType == PIM_FUNCTIONAL) {
-    // Read envirnment variable for the simulation target
+    // Read environment variable for the simulation target
     bool readSimTargetFromMakeArgument = false;
-    std::printf("PIM-Info: Trying to read simulation target from envirnment variable %s\n", pimUtils::envVarPimEvalTarget);
+    std::printf("PIM-Info: Trying to read simulation target from environment variable %s\n", pimUtils::envVarPimEvalTarget);
     std::string pimEvalTarget;
     bool readEnvVarStatus = pimUtils::getEnvVar(pimUtils::envVarPimEvalTarget, pimEvalTarget);
     if (!readEnvVarStatus) {
@@ -342,9 +342,9 @@ pimDevice::parseConfigFromFile(const std::string& config, unsigned& numRanks, un
   } catch (const std::invalid_argument& e) {
     std::string missing = e.what();
     if (missing == "simulation_target") {
-      // Read envirnment variable for the simulation target
+      // Read environment variable for the simulation target
       bool readSimTargetFromMakeArgument = false;
-      std::printf("PIM-Info: Trying to read simulation target from envirnment variable %s\n", pimUtils::envVarPimEvalTarget);
+      std::printf("PIM-Info: Trying to read simulation target from environment variable %s\n", pimUtils::envVarPimEvalTarget);
       std::string pimEvalTarget;
       bool readEnvVarStatus = pimUtils::getEnvVar(pimUtils::envVarPimEvalTarget, pimEvalTarget);
       if (!readEnvVarStatus) {

--- a/libpimeval/src/pimSim.cpp
+++ b/libpimeval/src/pimSim.cpp
@@ -83,6 +83,22 @@ pimSim::init(const std::string& simConfigFileConetnt)
       m_statsMgr = std::make_unique<pimStatsMgr>();
       m_initCalled = true;
     }
+
+    // Common PIMeval simulator settings
+    // ENV-VAR: PIMEVAL_ANALYSIS_MODE = [0|1] - Set to 1 for fast perf and energy analysis
+    // Warning: In this mode, PIM computation will be skipped. Do not use this for result-dependent PIM algorithms.
+    std::string analysisMode;
+    bool hasEnvVar = pimUtils::getEnvVar(pimUtils::envVarPimEvalAnalysisMode, analysisMode);
+    if (hasEnvVar) {
+      std::printf("PIM-Info: Environment variable %s = %s\n", pimUtils::envVarPimEvalAnalysisMode, analysisMode.c_str());
+      if (analysisMode == "1") {
+        std::printf("PIM-Info: Enabled analysis only mode. Ignoring computation during performance and energy analysis.\n");
+        m_analysisMode = true;
+      } else {
+        std::printf("PIM-Info: Disabled analysis only mode.\n");
+        m_analysisMode = false;
+      }
+    }
   }
   return true;
 }
@@ -95,6 +111,7 @@ pimSim::uninit()
   m_statsMgr.reset();
   m_paramsDram.reset();
   m_initCalled = false;
+  m_analysisMode = false;
 }
 
 //! @brief  Determine num threads and init thread pool

--- a/libpimeval/src/pimSim.h
+++ b/libpimeval/src/pimSim.h
@@ -47,6 +47,7 @@ public:
   pimStatsMgr* getStatsMgr() { return m_statsMgr.get(); }
   const pimParamsDram& getParamsDram() const { assert(m_paramsDram); return *m_paramsDram; }
   pimPerfEnergyBase* getPerfEnergyModel();
+  bool isAnalysisMode() const { return m_analysisMode; }
 
   void initThreadPool(unsigned maxNumThreads);
   pimUtils::threadPool* getThreadPool() { return m_threadPool.get(); }
@@ -145,6 +146,7 @@ private:
   std::unique_ptr<pimStatsMgr> m_statsMgr;
   std::unique_ptr<pimUtils::threadPool> m_threadPool;
   unsigned m_numThreads = 0;
+  bool m_analysisMode = false;
   std::string m_memConfigFileName;
   std::string m_configFilesPath;
   bool m_initCalled = false;

--- a/libpimeval/src/pimUtils.h
+++ b/libpimeval/src/pimUtils.h
@@ -115,6 +115,7 @@ namespace pimUtils
   static constexpr const char* envVarPimEvalTarget = "PIMEVAL_TARGET";
   static constexpr const char* envVarPimEvalConfigPath = "PIMEVAL_CONFIG_PATH";
   static constexpr const char* envVarPimEvalConfigSim = "PIMEVAL_CONFIG_SIM";
+  static constexpr const char* envVarPimEvalAnalysisMode = "PIMEVAL_ANALYSIS_MODE";
 
   //! @class  threadWorker
   //! @brief  Thread worker base class

--- a/tests/test-functional/test-functional-fp.h
+++ b/tests/test-functional/test-functional-fp.h
@@ -188,6 +188,11 @@ testFunctional::testFp(const std::string& category, PimDataType dataType)
     status = pimCopyDeviceToHost(objDest, (void *)vecDest.data());
     assert(status == PIM_OK);
 
+    // Skip result verification in analysis mode
+    if (pimIsAnalysisMode()) {
+      continue;
+    }
+
     // Verify results
     if (testName == "pimRedSumInt" || testName == "pimRedSumRangedInt") {
       uint64_t begin = (testName == "pimRedSumInt" ? 0 : idxBegin);

--- a/tests/test-functional/test-functional-int.h
+++ b/tests/test-functional/test-functional-int.h
@@ -186,6 +186,11 @@ testFunctional::testInt(const std::string& category, PimDataType dataType)
     status = pimCopyDeviceToHost(objDest, (void *)vecDest.data());
     assert(status == PIM_OK);
 
+    // Skip result verification in analysis mode
+    if (pimIsAnalysisMode()) {
+      continue;
+    }
+
     // Verify results
     if (testName == "pimRedSumInt" || testName == "pimRedSumRangedInt") {
       uint64_t begin = (testName == "pimRedSumInt" ? 0 : idxBegin);


### PR DESCRIPTION
**Feature**: PIMeval analysis mode, off by default experimental feature
**Purpose**: Fast performance and energy analysis, 2-10+x
**UI to enable**: Environment variable PIMEVAL\_ANALYSIS\_MODE=1 
**Impact**: Once enabled, PIMeval will skip data copying and PIM computation during simulation for fast runtime, while the performance and energy estimation results will be identically preserved.
**Limitation**: This mode works for result-independent PIM kernels. Result-dependent PIM kernel will not work because the PIM computation results are not usable. In addition, some applications need to guard some result verification code with pimIsAnalysisMode check.
