### PR TITLE
Fix histogram alternative to compile with new reduction sum

### DIFF
--- a/libpimeval/src/libpimeval.h
+++ b/libpimeval/src/libpimeval.h
@@ -150,7 +150,7 @@ PimStatus pimMaxScalar(PimObjId src, PimObjId dest, uint64_t scalarValue);
 // multiply src1 with scalarValue and add the multiplication result with src2. Save the result to dest. 
 PimStatus pimScaledAdd(PimObjId src1, PimObjId src2, PimObjId dest, uint64_t scalarValue);
 PimStatus pimPopCount(PimObjId src, PimObjId dest);
-PimStatus pimRedSum(PimObjId src, void* min, uint64_t idxBegin = 0, uint64_t idxEnd = 0);
+PimStatus pimRedSum(PimObjId src, void* sum, uint64_t idxBegin = 0, uint64_t idxEnd = 0);
 // Min/Max Reduction APIs
 PimStatus pimRedMin(PimObjId src, void* min, uint64_t idxBegin = 0, uint64_t idxEnd = 0);
 PimStatus pimRedMax(PimObjId src, void* max, uint64_t idxBegin = 0, uint64_t idxEnd = 0);

--- a/misc-bench/histogram-alt/hist-alt.cpp
+++ b/misc-bench/histogram-alt/hist-alt.cpp
@@ -91,17 +91,17 @@ void histogram(uint64_t imgDataBytes, const std::vector<uint8_t> &imgData, std::
     assert(status == PIM_OK);
 
     prevCount = blueCount[i];
-    status = pimRedSumRangedUInt(tempObj, 0, imgDataBytes / 3, &blueCount[i]);
+    status = pimRedSum(tempObj, &blueCount[i], 0, imgDataBytes / 3);
     assert(status == PIM_OK);
     blueCount[i] += prevCount;
 
     prevCount = greenCount[i];
-    status = pimRedSumRangedUInt(tempObj, imgDataBytes / 3, imgDataBytes * 2 / 3, &greenCount[i]);
+    status = pimRedSum(tempObj, &greenCount[i], imgDataBytes / 3, imgDataBytes * 2 / 3);
     assert(status == PIM_OK);
     greenCount[i] += prevCount;
 
     prevCount = redCount[i];
-    status = pimRedSumRangedUInt(tempObj, imgDataBytes * 2 / 3, imgDataBytes, &redCount[i]);
+    status = pimRedSum(tempObj, &redCount[i], imgDataBytes * 2 / 3, imgDataBytes);
     assert(status == PIM_OK);
     redCount[i] += prevCount;
   }


### PR DESCRIPTION
During testing, I noticed that compiling the full library no longer worked due to updates to the reduction sums in histogram alt. I have fixed this below, now the whole repository compiles, and I have checked the histogram alt changes using the default inputs.