### PR TITLE
Rename min to sum for pimRedSum parameter

### DIFF
--- a/libpimeval/src/libpimeval.h
+++ b/libpimeval/src/libpimeval.h
@@ -150,7 +150,7 @@ PimStatus pimMaxScalar(PimObjId src, PimObjId dest, uint64_t scalarValue);
 // multiply src1 with scalarValue and add the multiplication result with src2. Save the result to dest. 
 PimStatus pimScaledAdd(PimObjId src1, PimObjId src2, PimObjId dest, uint64_t scalarValue);
 PimStatus pimPopCount(PimObjId src, PimObjId dest);
-PimStatus pimRedSum(PimObjId src, void* min, uint64_t idxBegin = 0, uint64_t idxEnd = 0);
+PimStatus pimRedSum(PimObjId src, void* sum, uint64_t idxBegin = 0, uint64_t idxEnd = 0);
 // Min/Max Reduction APIs
 PimStatus pimRedMin(PimObjId src, void* min, uint64_t idxBegin = 0, uint64_t idxEnd = 0);
 PimStatus pimRedMax(PimObjId src, void* max, uint64_t idxBegin = 0, uint64_t idxEnd = 0);


### PR DESCRIPTION
The parameter in libpimeval.cpp is already named sum, but it is currently named min in libpimeval.h