### PR TITLE
Measure CPU/PIM portion of kernel runtime

### DIFF
--- a/libpimeval/src/libpimeval.cpp
+++ b/libpimeval/src/libpimeval.cpp
@@ -40,6 +40,20 @@ pimDeleteDevice()
   return ok ? PIM_OK : PIM_ERROR;
 }
 
+//! @brief  Start timer for a PIM kernel to measure CPU runtime and DRAM refresh
+void
+pimStartTimer()
+{
+  pimSim::get()->startKernelTimer();
+}
+
+//! @brief  End timer for a PIM kernel to measure CPU runtime and DRAM refresh
+void
+pimEndTimer()
+{
+  pimSim::get()->endKernelTimer();
+}
+
 //! @brief  Show PIM command stats
 void
 pimShowStats()

--- a/libpimeval/src/libpimeval.h
+++ b/libpimeval/src/libpimeval.h
@@ -93,6 +93,9 @@ typedef int PimCoreId;
 typedef int PimObjId;
 
 // PIMeval simulation
+// CPU runtime between start/end timer will be measured for modeling DRAM refresh
+void pimStartTimer();
+void pimEndTimer();
 void pimShowStats();
 void pimResetStats();
 bool pimIsAnalysisMode();

--- a/libpimeval/src/pimSim.cpp
+++ b/libpimeval/src/pimSim.cpp
@@ -375,6 +375,20 @@ pimSim::getPerfEnergyModel()
   return nullptr;
 }
 
+//! @brief  Start timer for a PIM kernel to measure CPU runtime and DRAM refresh
+void
+pimSim::startKernelTimer() const
+{
+  m_statsMgr->startKernelTimer();
+}
+
+//! @brief  End timer for a PIM kernel to measure CPU runtime and DRAM refresh
+void
+pimSim::endKernelTimer() const
+{
+  m_statsMgr->endKernelTimer();
+}
+
 //! @brief  Show PIM command stats
 void
 pimSim::showStats() const

--- a/libpimeval/src/pimSim.h
+++ b/libpimeval/src/pimSim.h
@@ -42,6 +42,8 @@ public:
   unsigned getNumRows() const;
   unsigned getNumCols() const;
 
+  void startKernelTimer() const;
+  void endKernelTimer() const;
   void showStats() const;
   void resetStats() const;
   pimStatsMgr* getStatsMgr() { return m_statsMgr.get(); }

--- a/libpimeval/src/pimStats.h
+++ b/libpimeval/src/pimStats.h
@@ -37,41 +37,22 @@ public:
   pimStatsMgr() {}
   ~pimStatsMgr() {}
 
+  void startKernelTimer();
+  void endKernelTimer();
+
   void showStats() const;
   void resetStats();
-  
-  void recordCmd(const std::string& cmdName, pimeval::perfEnergy mPerfEnergy) {
-    auto& item = m_cmdPerf[cmdName];
-    item.first++;
-    item.second.m_msRuntime += mPerfEnergy.m_msRuntime;
-    item.second.m_mjEnergy += mPerfEnergy.m_mjEnergy;
-  }
 
-  void recordMsElapsed(const std::string& tag, double elapsed) {
-    auto& item = m_msElapsed[tag];
-    item.first++;
-    item.second += elapsed;
-  }
-
-  void recordCopyMainToDevice(uint64_t numBits, pimeval::perfEnergy mPerfEnergy) {
-    m_bitsCopiedMainToDevice += numBits;
-    m_elapsedTimeCopiedMainToDevice += mPerfEnergy.m_msRuntime;
-    m_mJCopiedMainToDevice += mPerfEnergy.m_mjEnergy;
-  }
-
-  void recordCopyDeviceToMain(uint64_t numBits, pimeval::perfEnergy mPerfEnergy) {
-    m_bitsCopiedDeviceToMain += numBits; 
-    m_elapsedTimeCopiedDeviceToMain += mPerfEnergy.m_msRuntime;
-    m_mJCopiedDeviceToMain += mPerfEnergy.m_mjEnergy;
-  }
-  
-  void recordCopyDeviceToDevice(uint64_t numBits, pimeval::perfEnergy mPerfEnergy) {
-    m_bitsCopiedDeviceToDevice += numBits;
-    m_elapsedTimeCopiedDeviceToDevice += mPerfEnergy.m_msRuntime;
-    m_mJCopiedDeviceToDevice += mPerfEnergy.m_mjEnergy;
-  }
+  void recordCmd(const std::string& cmdName, pimeval::perfEnergy mPerfEnergy);
+  void recordCopyMainToDevice(uint64_t numBits, pimeval::perfEnergy mPerfEnergy);
+  void recordCopyDeviceToMain(uint64_t numBits, pimeval::perfEnergy mPerfEnergy);
+  void recordCopyDeviceToDevice(uint64_t numBits, pimeval::perfEnergy mPerfEnergy);
 
 private:
+  friend class pimPerfMon;
+  void pimApiScopeStart();
+  void pimApiScopeEnd(const std::string& tag, double elapsed);
+
   void showApiStats() const;
   void showDeviceParams() const;
   void showCopyStats() const;
@@ -89,6 +70,12 @@ private:
   double m_mJCopiedMainToDevice = 0.0;
   double m_mJCopiedDeviceToMain = 0.0;
   double m_mJCopiedDeviceToDevice = 0.0;
+
+  bool m_isKernelTimerOn = false;
+  double m_curApiMsEstRuntime = 0.0;
+  double m_kernelMsElapsedSim = 0.0;
+  double m_kernelMsEstRuntime = 0.0;
+  std::chrono::time_point<std::chrono::high_resolution_clock> m_kernelStart{};
 };
 
 #endif

--- a/tests/bitsimd-perf/bitsimd-perf.cpp
+++ b/tests/bitsimd-perf/bitsimd-perf.cpp
@@ -71,7 +71,10 @@ int main()
     return 1;
   }
 
+  pimStartTimer();
   ok = testMicroOps();
+  pimEndTimer();
+
   if (!ok) {
     std::cout << "Test failed!" << std::endl;
     return 1;


### PR DESCRIPTION
Purpose: Measure CPU/PIM portion of kernel runtime for modeling refresh. CPU runtime is based on real elapsed time. PIM runtime is based on estimated runtime.
Changes:
- Add pimStartTimer and pimEndTimer APIs to mark boundary of kernels and track CPU and PIM runtime separately
- Show stats when pimEndTimer is called

