### PR TITLE
Support pimConvertType API as part of mixed data type support.

### DIFF
--- a/libpimeval/src/libpimeval.cpp
+++ b/libpimeval/src/libpimeval.cpp
@@ -157,6 +157,13 @@ PimStatus pimCopyObjectToObject(PimObjId src, PimObjId dest)
   return ok ? PIM_OK : PIM_ERROR;
 }
 
+//! @brief  Convert data type between two associated PIM objects of different data types
+PimStatus pimConvertType(PimObjId src, PimObjId dest)
+{
+  bool ok = pimSim::get()->pimConvertType(src, dest);
+  return ok ? PIM_OK : PIM_ERROR;
+}
+
 //! @brief  Load vector with a signed int value
 PimStatus
 pimBroadcastInt(PimObjId dest, int64_t value)

--- a/libpimeval/src/libpimeval.h
+++ b/libpimeval/src/libpimeval.h
@@ -128,6 +128,7 @@ PimStatus pimCopyHostToDeviceWithType(PimCopyEnum copyType, void* src, PimObjId 
 PimStatus pimCopyDeviceToHostWithType(PimCopyEnum copyType, PimObjId src, void* dest, uint64_t idxBegin = 0, uint64_t idxEnd = 0);
 PimStatus pimCopyDeviceToDevice(PimObjId src, PimObjId dest, uint64_t idxBegin = 0, uint64_t idxEnd = 0);
 PimStatus pimCopyObjectToObject(PimObjId src, PimObjId dest);
+PimStatus pimConvertType(PimObjId src, PimObjId dest);
 
 // Logic and Arithmetic Operation
 PimStatus pimAdd(PimObjId src1, PimObjId src2, PimObjId dest);

--- a/libpimeval/src/pimCmd.h
+++ b/libpimeval/src/pimCmd.h
@@ -45,6 +45,7 @@ enum class PimCmdEnum {
   EQ_SCALAR,
   MIN_SCALAR,
   MAX_SCALAR,
+  CONVERT_TYPE,
   // Functional 2-operand
   ADD,
   SUB,
@@ -305,6 +306,8 @@ private:
     }
     return true;
   }
+
+  bool convertType(const pimObjInfo& objSrc, pimObjInfo& objDest, uint64_t elemIdx) const;
 };
 
 //! @class  pimCmdFunc2

--- a/libpimeval/src/pimPerfEnergyBitSerial.cpp
+++ b/libpimeval/src/pimPerfEnergyBitSerial.cpp
@@ -7,6 +7,7 @@
 #include "pimPerfEnergyBitSerial.h"
 #include "pimCmd.h"
 #include "pimPerfEnergyTables.h"
+#include "pimUtils.h"
 #include <iostream>
 #include <cmath> // For log2()
 
@@ -147,9 +148,7 @@ pimPerfEnergyBitSerial::getPerfEnergyForReduction(PimCmdEnum cmdType, const pimO
     case PIM_DEVICE_BITSIMD_V:
     case PIM_DEVICE_BITSIMD_V_AP:
     {
-      if (dataType == PIM_BOOL ||
-          dataType == PIM_INT8 || dataType == PIM_INT16 || dataType == PIM_INT32 || dataType == PIM_INT64 ||
-          dataType == PIM_UINT8 || dataType == PIM_UINT16 || dataType == PIM_UINT32 || dataType == PIM_UINT64) {
+      if (pimUtils::isSigned(dataType) || pimUtils::isUnsigned(dataType)) {
         switch (cmdType)
         {
         case PimCmdEnum::REDSUM:
@@ -204,12 +203,10 @@ pimPerfEnergyBitSerial::getPerfEnergyForReduction(PimCmdEnum cmdType, const pimO
           break;
         }
         }
-      }
-      else if (dataType == PIM_FP32 || dataType == PIM_FP16 || dataType == PIM_BF16 || dataType == PIM_FP8)
-      {
-            std::cout << "PIM-Warning: Perf energy model for FP reduction sum on bit-serial PIM is not available yet." << std::endl;
-            msRuntime = 999999999.9; // todo
-            mjEnergy = 999999999.9;  // todo
+      } else if (pimUtils::isFP(dataType)) {
+        std::cout << "PIM-Warning: Perf energy model for FP reduction sum on bit-serial PIM is not available yet." << std::endl;
+        msRuntime = 999999999.9; // todo
+        mjEnergy = 999999999.9;  // todo
       } else {
         assert(0);
       }

--- a/libpimeval/src/pimSim.cpp
+++ b/libpimeval/src/pimSim.cpp
@@ -502,6 +502,15 @@ bool pimSim::pimCopyObjectToObject(PimObjId src, PimObjId dest)
   return m_device->executeCmd(std::move(cmd));
 }
 
+bool
+pimSim::pimConvertType(PimObjId src, PimObjId dest)
+{
+  pimPerfMon perfMon("pimConvertType");
+  if (!isValidDevice()) { return false; }
+  std::unique_ptr<pimCmd> cmd = std::make_unique<pimCmdFunc1>(PimCmdEnum::CONVERT_TYPE, src, dest);
+  return m_device->executeCmd(std::move(cmd));
+}
+
 // @brief  Load vector with a scalar value
 template <typename T> bool
 pimSim::pimBroadcast(PimObjId dest, T value)
@@ -543,7 +552,7 @@ pimSim::pimDiv(PimObjId src1, PimObjId src2, PimObjId dest)
   return m_device->executeCmd(std::move(cmd));
 }
 
-// @brief  PIM OP: abs v-layout
+// @brief  PIM OP: abs
 bool
 pimSim::pimAbs(PimObjId src, PimObjId dest)
 {

--- a/libpimeval/src/pimSim.h
+++ b/libpimeval/src/pimSim.h
@@ -69,6 +69,7 @@ public:
   bool pimCopyDeviceToMainWithType(PimCopyEnum copyType, PimObjId src, void* dest, uint64_t idxBegin = 0, uint64_t idxEnd = 0);
   bool pimCopyDeviceToDevice(PimObjId src, PimObjId dest, uint64_t idxBegin = 0, uint64_t idxEnd = 0);
   bool pimCopyObjectToObject(PimObjId src, PimObjId dest);
+  bool pimConvertType(PimObjId src, PimObjId dest);
 
   // Computation
   bool pimAdd(PimObjId src1, PimObjId src2, PimObjId dest);

--- a/libpimeval/src/pimUtils.cpp
+++ b/libpimeval/src/pimUtils.cpp
@@ -118,6 +118,27 @@ pimUtils::getNumBitsOfDataType(PimDataType dataType)
   return 0;
 }
 
+//! @brief  Check if a PIM data type is signed integer
+bool
+pimUtils::isSigned(PimDataType dataType)
+{
+  return dataType == PIM_INT8 || dataType == PIM_INT16 || dataType == PIM_INT32 || dataType == PIM_INT64;
+}
+
+//! @brief  Check if a PIM data type is unsigned integer
+bool
+pimUtils::isUnsigned(PimDataType dataType)
+{
+  return dataType == PIM_BOOL || dataType == PIM_UINT8 || dataType == PIM_UINT16 || dataType == PIM_UINT32 || dataType == PIM_UINT64;
+}
+
+//! @brief  Check if a PIM data type is floating point
+bool
+pimUtils::isFP(PimDataType dataType)
+{
+  return dataType == PIM_FP32 || dataType == PIM_FP16 || dataType == PIM_BF16 || dataType == PIM_FP8;
+}
+
 //! @brief  Thread pool ctor
 pimUtils::threadPool::threadPool(size_t numThreads)
   : m_terminate(false),

--- a/libpimeval/src/pimUtils.h
+++ b/libpimeval/src/pimUtils.h
@@ -32,6 +32,9 @@ namespace pimUtils
   std::string pimCopyEnumToStr(PimCopyEnum copyType);
   std::string pimDataTypeEnumToStr(PimDataType dataType);
   unsigned getNumBitsOfDataType(PimDataType dataType);
+  bool isSigned(PimDataType dataType);
+  bool isUnsigned(PimDataType dataType);
+  bool isFP(PimDataType dataType);
 
   // Convert raw bits into sign-extended bits based on PIM data type.
   // Input: Raw bits represented as uint64_t


### PR DESCRIPTION
Main changes:
- Add a new pimConvertType API
- Define a new CONVERT_TYPE command (does not support int-fp conversion for now)
- Minor cleanup for isSigned/isUnsigned/isFP

This is part of mixed data type support and does not affect existing simulation results. Will add more testing in following check-ins.

@fasiddique Appreciate your review effort. Thanks!