### PR TITLE
Simplify multiple copies of config file parsing code in libpimeval

### DIFF
--- a/libpimeval/src/pimCmd.cpp
+++ b/libpimeval/src/pimCmd.cpp
@@ -10,20 +10,11 @@
 #include "pimCore.h"         // for pimCore
 #include "pimResMgr.h"       // for pimResMgr
 #include "libpimeval.h"      // for PimObjId
-#include <cstdio>            // for printf
-#include <unordered_map>     // for unordered_map
-#include <unordered_set>     // for unordered_set
-#include "pimCmd.h"
-#include "pimSim.h"
-#include "pimDevice.h"
-#include "pimCore.h"
-#include "pimResMgr.h"
 #include <cstdio>
 #include <cmath>
 #include <unordered_map>
 #include <unordered_set>
 #include <climits>
-#include <cmath>
 
 //! @brief  Get PIM command name from command type enum
 std::string

--- a/libpimeval/src/pimDevice.cpp
+++ b/libpimeval/src/pimDevice.cpp
@@ -13,7 +13,6 @@
 #include <deque>
 #include <memory>
 #include <cassert>
-#include <sstream>
 #include <string>
 #include <unordered_map>
 #include <algorithm>
@@ -255,15 +254,8 @@ pimDevice::init(PimDeviceEnum deviceType, const char* configFileName)
   unsigned numCols;
   bool isLoadBalanced;
 
-  std::string fileContent;
-  success = pimUtils::readFileContent(configFileName, fileContent);
-  if (!success) {
-    std::printf("PIM-Error: Failed to read config file %s\n", configFileName);
-    return false;
-  }
-
   // input params
-  success = parseConfigFromFile(fileContent, numRanks, numBankPerRank, numSubarrayPerBank, numRows, numCols, isLoadBalanced);
+  success = parseConfigFromFile(configFileName, numRanks, numBankPerRank, numSubarrayPerBank, numRows, numCols, isLoadBalanced);
   if (!success) {
     std::printf("PIM-Error: Failed to parse config file %s\n", configFileName);
     return false;
@@ -328,24 +320,10 @@ pimDevice::init(PimDeviceEnum deviceType, const char* configFileName)
 
 //! @brief Initilize the device config parameters by parsing the config file
 bool
-pimDevice::parseConfigFromFile(const std::string& config, unsigned& numRanks, unsigned& numBankPerRank, unsigned& numSubarrayPerBank, unsigned& numRows, unsigned& numCols, bool& isLoadBalanced)
+pimDevice::parseConfigFromFile(const std::string& simConfigFilePath, unsigned& numRanks, unsigned& numBankPerRank, unsigned& numSubarrayPerBank, unsigned& numRows, unsigned& numCols, bool& isLoadBalanced)
 {
-  std::istringstream configStream(config);
-  std::string line;
-  std::unordered_map<std::string, std::string> params;
+  std::unordered_map<std::string, std::string> params = pimUtils::readParamsFromConfigFile(simConfigFilePath);
 
-  while (std::getline(configStream, line)) {
-    line = pimUtils::removeAfterSemicolon(line);
-    if (line.empty() || line[0] == '[') {
-      continue;
-    }
-    size_t equalPos = line.find('=');
-    if (equalPos != std::string::npos) {
-      std::string key = line.substr(0, equalPos);
-      std::string value = line.substr(equalPos + 1);
-      params[pimUtils::trim(key)] = pimUtils::trim(value);
-    }
-  }
   try {
     numRanks = std::stoi(pimUtils::getParam(params, "num_ranks"));
     numBankPerRank = std::stoi(pimUtils::getParam(params, "num_bank_per_rank"));

--- a/libpimeval/src/pimDevice.h
+++ b/libpimeval/src/pimDevice.h
@@ -69,7 +69,7 @@ public:
 private:
   bool adjustConfigForSimTarget(unsigned& numRanks, unsigned& numBankPerRank, unsigned& numSubarrayPerBank, unsigned& numRows, unsigned& numCols);
   void configSimTarget(PimDeviceEnum deviceType = PIM_FUNCTIONAL);
-  bool parseConfigFromFile(const std::string& config, unsigned& numRanks, unsigned& numBankPerRank, unsigned& numSubarrayPerBank, unsigned& numRows, unsigned& numCols, bool& isLoadBalanced);
+  bool parseConfigFromFile(const std::string& simConfigFilePath, unsigned& numRanks, unsigned& numBankPerRank, unsigned& numSubarrayPerBank, unsigned& numRows, unsigned& numCols, bool& isLoadBalanced);
 
   PimDeviceEnum m_deviceType = PIM_DEVICE_NONE;
   PimDeviceEnum m_simTarget = PIM_DEVICE_NONE;

--- a/libpimeval/src/pimParamsDram.cpp
+++ b/libpimeval/src/pimParamsDram.cpp
@@ -9,7 +9,6 @@
 #include "pimParamsDDRDram.h"
 #include "pimParamsLPDDRDram.h"
 #include "pimParamsHBMDram.h"
-#include <sstream>
 #include <string>
 #include <algorithm>
 #include <cctype>
@@ -39,29 +38,9 @@ std::unique_ptr<pimParamsDram> pimParamsDram::create(PimDeviceProtocolEnum devic
 }
 
 // Static factory method to create appropriate subclass based on config file
-std::unique_ptr<pimParamsDram> pimParamsDram::createFromConfig(const std::string& config)
+std::unique_ptr<pimParamsDram> pimParamsDram::createFromConfig(const std::string& memConfigFilePath)
 {
-  std::istringstream configStream(config);
-  std::string line;
-  std::unordered_map<std::string, std::string> params;
-
-  while (std::getline(configStream, line))
-  {
-    line = pimUtils::removeAfterSemicolon(line);
-    if (line.empty() || line[0] == '[')
-    {
-      continue; // Skip section headers and empty lines
-    }
-
-    // Parse key-value pairs
-    size_t equalPos = line.find('=');
-    if (equalPos != std::string::npos)
-    {
-      std::string key = line.substr(0, equalPos);
-      std::string value = line.substr(equalPos + 1);
-      params[pimUtils::trim(key)] = pimUtils::trim(value); // Store in params map
-    }
-  }
+  std::unordered_map<std::string, std::string> params = pimUtils::readParamsFromConfigFile(memConfigFilePath);
 
   // Check if the "protocol" key exists
   if (params.find("protocol") == params.end())

--- a/libpimeval/src/pimParamsDram.h
+++ b/libpimeval/src/pimParamsDram.h
@@ -23,7 +23,7 @@ public:
   static std::unique_ptr<pimParamsDram> create(PimDeviceProtocolEnum deviceProtocol);
 
   // Static factory method to create appropriate subclass based on config file
-  static std::unique_ptr<pimParamsDram> createFromConfig(const std::string& config);
+  static std::unique_ptr<pimParamsDram> createFromConfig(const std::string& memConfigFilePath);
 
   // Virtual functions for protocol-specific implementation
   virtual int getDeviceWidth() const = 0;

--- a/libpimeval/src/pimSim.cpp
+++ b/libpimeval/src/pimSim.cpp
@@ -15,7 +15,6 @@
 #include <cctype>
 #include <locale>
 #include <stdexcept>
-#include <sstream>
 #include <filesystem>
 #include <string>
 
@@ -55,23 +54,18 @@ pimSim::~pimSim()
 
 //! @brief  Initialize pimSim member classes from the config file
 bool
-pimSim::init(const std::string& simConfigFileConetnt)
+pimSim::init(const std::string& simConfigFilePath)
 {
   if (!m_initCalled) {
-    if (!simConfigFileConetnt.empty()) {
-      bool success = parseConfigFromFile(simConfigFileConetnt);
+    if (!simConfigFilePath.empty()) {
+      bool success = parseConfigFromFile(simConfigFilePath);
       if (!success) {
         return false;
       }
 
       if (!m_memConfigFileName.empty()) {
         std::string memConfigFileFullPath = m_configFilesPath + m_memConfigFileName;
-        std::string fileContent;
-        success = pimUtils::readFileContent(memConfigFileFullPath.c_str(), fileContent);
-        if (!success) {
-          return false;
-        }
-        m_paramsDram = pimParamsDram::createFromConfig(fileContent);
+        m_paramsDram = pimParamsDram::createFromConfig(memConfigFileFullPath);
       } else {
         m_paramsDram = pimParamsDram::create(PIM_DEVICE_PROTOCOL_DDR);
       }
@@ -193,16 +187,9 @@ pimSim::createDeviceFromConfig(PimDeviceEnum deviceType, const char* configFileN
     return false;
   }
 
-  std::string fileContent;
-  success = pimUtils::readFileContent(correctConfigFileName.c_str(), fileContent);
-  if (!success) {
-    std::printf("PIM-Error: Failed to read config file %s\n", correctConfigFileName.c_str());
-    return false;
-  }
-
   m_configFilesPath = pimUtils::getDirectoryPath(correctConfigFileName);
 
-  success = init(fileContent);
+  success = init(correctConfigFileName);
   if (!success) {
     std::printf("PIM-Error: Init failed\n");
     return false;
@@ -1157,23 +1144,10 @@ pimSim::pimOpAAP(int numSrc, int numDest, va_list args)
 
 //! @breif parse config file to get memory config file path and maximum number of threads
 bool
-pimSim::parseConfigFromFile(const std::string& simConfigFileConetnt) {
-  std::istringstream configStream(simConfigFileConetnt);
-  std::string line;
-  std::unordered_map<std::string, std::string> params;
+pimSim::parseConfigFromFile(const std::string& simConfigFilePath)
+{
+  std::unordered_map<std::string, std::string> params = pimUtils::readParamsFromConfigFile(simConfigFilePath);
 
-  while (std::getline(configStream, line)) {
-    line = pimUtils::removeAfterSemicolon(line);
-    if (line.empty() || line[0] == '[') {
-      continue;
-    }
-    size_t equalPos = line.find('=');
-    if (equalPos != std::string::npos) {
-      std::string key = line.substr(0, equalPos);
-      std::string value = line.substr(equalPos + 1);
-      params[pimUtils::trim(key)] = pimUtils::trim(value);
-    }
-  }
   try {
     bool success = false;
     std::string temp;

--- a/libpimeval/src/pimSim.h
+++ b/libpimeval/src/pimSim.h
@@ -139,9 +139,9 @@ private:
   ~pimSim();
   pimSim(const pimSim&) = delete;
   pimSim operator=(const pimSim&) = delete;
-  bool init(const std::string& simConfigFileContent = "");
+  bool init(const std::string& simConfigFilePath = "");
   void uninit();
-  bool parseConfigFromFile(const std::string& simConfigFileContent);
+  bool parseConfigFromFile(const std::string& simConfigFilePath);
 
   static pimSim* s_instance;
 

--- a/libpimeval/src/pimUtils.cpp
+++ b/libpimeval/src/pimUtils.cpp
@@ -278,3 +278,35 @@ pimUtils::getDirectoryPath(const std::string& filePath) {
     std::filesystem::path path(filePath);
     return path.parent_path().string() + "/";
 }
+
+//! @brief Given a config file path, read all parameters
+std::unordered_map<std::string, std::string>
+pimUtils::readParamsFromConfigFile(const std::string& configFilePath)
+{
+  std::unordered_map<std::string, std::string> params;
+  if (configFilePath.empty()) {
+    return params;
+  }
+  std::string contents;
+  bool success = pimUtils::readFileContent(configFilePath.c_str(), contents);
+  if (!success) {
+    std::printf("PIM-Error: Failed to read config file %s\n", configFilePath.c_str());
+    return params;
+  }
+  std::istringstream iss(contents);
+  std::string line;
+  while (std::getline(iss, line)) {
+    line = pimUtils::removeAfterSemicolon(line);
+    if (line.empty() || line[0] == '[') {
+      continue;
+    }
+    size_t equalPos = line.find('=');
+    if (equalPos != std::string::npos) {
+      std::string key = line.substr(0, equalPos);
+      std::string value = line.substr(equalPos + 1);
+      params[pimUtils::trim(key)] = pimUtils::trim(value);
+    }
+  }
+  return params;
+}
+

--- a/libpimeval/src/pimUtils.h
+++ b/libpimeval/src/pimUtils.h
@@ -79,6 +79,7 @@ namespace pimUtils
 
   std::string getDirectoryPath(const std::string& filePath);
   bool getEnvVar(const std::string &varName, std::string &varValue);
+  std::unordered_map<std::string, std::string> readParamsFromConfigFile(const std::string& configFilePath);
 
   const std::unordered_map<PimDeviceEnum, std::string> enumToStrMap = {
       {PIM_DEVICE_NONE, "PIM_DEVICE_NONE"},


### PR DESCRIPTION
Main changes:
- Add pimUtils::readParamsFromConfigFile
- Consolidate three copies of config file parsing code

No impact on simulation results or simulator behavior. These are safe and clean changes that can be merged directly.

@fasiddique Appreciate your review effort. Thanks!