### PR TITLE
Support simulation target in device property API.

### DIFF
--- a/libpimeval/src/libpimeval.h
+++ b/libpimeval/src/libpimeval.h
@@ -87,6 +87,7 @@ enum PimDataType {
 //! @brief  PIM device properties
 struct PimDeviceProperties {
   PimDeviceEnum deviceType = PIM_DEVICE_NONE;
+  PimDeviceEnum simTarget = PIM_DEVICE_NONE;
   unsigned numRanks = 0;
   unsigned numBankPerRank = 0;
   unsigned numSubarrayPerBank = 0;

--- a/libpimeval/src/pimSim.cpp
+++ b/libpimeval/src/pimSim.cpp
@@ -220,6 +220,7 @@ pimSim::getDeviceProperties(PimDeviceProperties* deviceProperties) {
     return false;
   }
   deviceProperties->deviceType = m_device->getDeviceType();
+  deviceProperties->simTarget = m_device->getSimTarget();
   deviceProperties->numRanks = m_device->getNumRanks();
   deviceProperties->numBankPerRank = m_device->getNumBankPerRank();
   deviceProperties->numSubarrayPerBank = m_device->getNumSubarrayPerBank();

--- a/tests/test-device-APIs/test-device-APIs.cpp
+++ b/tests/test-device-APIs/test-device-APIs.cpp
@@ -12,9 +12,8 @@
 
 void testDeviceAPIs(PimDeviceEnum deviceType)
 {
-  // 8GB capacity
-  unsigned numRanks = 4;
-  unsigned numBankPerRank = 32; // 8 chips * 16 banks
+  unsigned numRanks = 1;
+  unsigned numBankPerRank = 2;
   unsigned numSubarrayPerBank = 16;
   unsigned numRows = 1024;
   unsigned numCols = 4096;
@@ -31,6 +30,16 @@ void testDeviceAPIs(PimDeviceEnum deviceType)
   assert(deviceProp.numSubarrayPerBank == numSubarrayPerBank);
   assert(deviceProp.numColPerSubarray == numCols);
   assert(deviceProp.numRowPerSubarray == numRows);
+
+  // Special handling for functional simulation target
+  if (deviceType == PIM_FUNCTIONAL) {
+    assert(deviceProp.simTarget != PIM_FUNCTIONAL);
+    assert(deviceProp.simTarget != PIM_DEVICE_NONE);
+    deviceType = deviceProp.simTarget;
+  } else {
+    assert(deviceProp.simTarget == deviceType);
+  }
+
   switch(deviceType) {
     case PIM_DEVICE_BITSIMD_V:
       assert(deviceProp.isHLayoutDevice == false);
@@ -44,7 +53,7 @@ void testDeviceAPIs(PimDeviceEnum deviceType)
     default:
       break;
   }
-  
+
   pimShowStats();
   pimDeleteDevice();
 }
@@ -56,6 +65,7 @@ int main()
   testDeviceAPIs(PIM_DEVICE_BITSIMD_V);
   testDeviceAPIs(PIM_DEVICE_FULCRUM);
   testDeviceAPIs(PIM_DEVICE_BANK_LEVEL);
+  testDeviceAPIs(PIM_FUNCTIONAL);
 
   std::cout << "PIM Regression Test: Device Related APIs Passed!" << std::endl;
 


### PR DESCRIPTION
Main changes:
- Add simTarget field to PimDeviceProperties struct
- Update regression test

Per request from @mhgholamrezaei : 
During functional simulation, we would like to query the simulation target in application code.

No impact on existing behavior.