### PR TITLE
Support bit slice operations: pimBitSliceExtract and pimBitSliceInsert

### DIFF
--- a/libpimeval/src/libpimeval.cpp
+++ b/libpimeval/src/libpimeval.cpp
@@ -414,6 +414,22 @@ pimPopCount(PimObjId src, PimObjId dest)
   return ok ? PIM_OK : PIM_ERROR;
 }
 
+//! @brief  Extract a bit slice from a data vector. Dest must be BOOL type
+PimStatus
+pimBitSliceExtract(PimObjId src, PimObjId destBool, unsigned bitIdx)
+{
+  bool ok = pimSim::get()->pimBitSliceExtract(src, destBool, bitIdx);
+  return ok ? PIM_OK : PIM_ERROR;
+}
+
+//! @brief  Insert a bit slice to a data vector. Src must be BOOL type
+PimStatus
+pimBitSliceInsert(PimObjId srcBool, PimObjId dest, unsigned bitIdx)
+{
+  bool ok = pimSim::get()->pimBitSliceInsert(srcBool, dest, bitIdx);
+  return ok ? PIM_OK : PIM_ERROR;
+}
+
 // Implementation of min reduction
 PimStatus pimRedMin(PimObjId src, void* min, uint64_t idxBegin, uint64_t idxEnd) {
     bool ok = pimSim::get()->pimRedMin(src, min, idxBegin, idxEnd);

--- a/libpimeval/src/libpimeval.h
+++ b/libpimeval/src/libpimeval.h
@@ -167,6 +167,9 @@ PimStatus pimRedSum(PimObjId src, void* sum, uint64_t idxBegin = 0, uint64_t idx
 // Min/Max Reduction APIs
 PimStatus pimRedMin(PimObjId src, void* min, uint64_t idxBegin = 0, uint64_t idxEnd = 0);
 PimStatus pimRedMax(PimObjId src, void* max, uint64_t idxBegin = 0, uint64_t idxEnd = 0);
+// Bit slice operations
+PimStatus pimBitSliceExtract(PimObjId src, PimObjId destBool, unsigned bitIdx);
+PimStatus pimBitSliceInsert(PimObjId srcBool, PimObjId dest, unsigned bitIdx);
 
 // Note: Reduction sum range is [idxBegin, idxEnd)
 

--- a/libpimeval/src/pimCmd.cpp
+++ b/libpimeval/src/pimCmd.cpp
@@ -395,7 +395,7 @@ pimCmdFunc1::sanityCheck() const
       case PimCmdEnum::BIT_SLICE_EXTRACT:
       case PimCmdEnum::BIT_SLICE_INSERT:
         break;
-     default:
+      default:
         std::printf("PIM-Error: PIM command %s does not support PIM_BOOL type\n", getName().c_str());
         return false;
     }

--- a/libpimeval/src/pimCmd.h
+++ b/libpimeval/src/pimCmd.h
@@ -47,6 +47,8 @@ enum class PimCmdEnum {
   MIN_SCALAR,
   MAX_SCALAR,
   CONVERT_TYPE,
+  BIT_SLICE_EXTRACT,
+  BIT_SLICE_INSERT,
   // Functional 2-operand
   ADD,
   SUB,
@@ -312,6 +314,8 @@ private:
   }
 
   bool convertType(const pimObjInfo& objSrc, pimObjInfo& objDest, uint64_t elemIdx) const;
+  bool bitSliceExtract(const pimObjInfo& objSrc, pimObjInfo& objDestBool, uint64_t bitIdx, uint64_t elemIdx) const;
+  bool bitSliceInsert(const pimObjInfo& objSrcBool, pimObjInfo& objDest, uint64_t bitIdx, uint64_t elemIdx) const;
 };
 
 //! @class  pimCmdFunc2

--- a/libpimeval/src/pimPerfEnergyBankLevel.cpp
+++ b/libpimeval/src/pimPerfEnergyBankLevel.cpp
@@ -39,7 +39,14 @@ pimPerfEnergyBankLevel::getPerfEnergyForFunc1(PimCmdEnum cmdType, const pimObjIn
     case PimCmdEnum::SUB_SCALAR:
     case PimCmdEnum::MUL_SCALAR:
     case PimCmdEnum::DIV_SCALAR:
+    case PimCmdEnum::BIT_SLICE_EXTRACT:
+    case PimCmdEnum::BIT_SLICE_INSERT:
     {
+      if (cmdType == PimCmdEnum::BIT_SLICE_EXTRACT) {
+        numberOfOperationPerElement *= 2; // 1 shift, 1 and
+      } else if (cmdType == PimCmdEnum::BIT_SLICE_INSERT) {
+        numberOfOperationPerElement *= 5; // 2 shifts, 1 not, 1 and, 1 or
+      }
       // How many iteration require to read / write max elements per region
       unsigned numGDLItr = maxElementsPerRegion * bitsPerElement / m_GDLWidth;
       double totalGDLOverhead = m_tGDL * numGDLItr; // read can be pipelined and write cannot be pipelined

--- a/libpimeval/src/pimPerfEnergyBitSerial.cpp
+++ b/libpimeval/src/pimPerfEnergyBitSerial.cpp
@@ -46,10 +46,26 @@ pimPerfEnergyBitSerial::getPerfEnergyBitSerial(PimDeviceEnum deviceType, PimCmdE
           }
         }
       }
-      // handle bit-shift specially
-      if (cmdType == PimCmdEnum::SHIFT_BITS_L || cmdType == PimCmdEnum::SHIFT_BITS_R) {
-        msRuntime += m_tR * (bitsPerElement - 1) + m_tW * bitsPerElement + m_tL;
-        ok = true;
+      // handle bit-serial operations not in the above table
+      if (!ok) {
+        switch (cmdType) {
+          case PimCmdEnum::BIT_SLICE_EXTRACT:
+          case PimCmdEnum::BIT_SLICE_INSERT:
+            // each bit-slice extract/insert operation takes 1 row read and 1 row write
+            msRuntime += m_tR + m_tW;
+            mjEnergy += (m_eAP + m_eAP) * numCores;
+            mjEnergy += m_pBChip * m_numChipsPerRank * m_numRanks * msRuntime;
+            ok = true;
+            break;
+          case PimCmdEnum::SHIFT_BITS_L:
+          case PimCmdEnum::SHIFT_BITS_R:
+            // handle bit-shift specially
+            msRuntime += m_tR * (bitsPerElement - 1) + m_tW * bitsPerElement + m_tL;
+            ok = true;
+            break;
+          default:
+            ; // pass
+        }
       }
       break;
     }

--- a/libpimeval/src/pimPerfEnergyFulcrum.cpp
+++ b/libpimeval/src/pimPerfEnergyFulcrum.cpp
@@ -49,6 +49,22 @@ pimPerfEnergyFulcrum::getPerfEnergyForFunc1(PimCmdEnum cmdType, const pimObjInfo
       mjEnergy += m_pBChip * m_numChipsPerRank * m_numRanks * msRuntime;
       break;
     }
+    case PimCmdEnum::BIT_SLICE_EXTRACT:
+    case PimCmdEnum::BIT_SLICE_INSERT:
+    {
+      if (cmdType == PimCmdEnum::BIT_SLICE_EXTRACT) {
+        numberOfALUOperationPerElement *= 2; // 1 shift, 1 and
+      } else if (cmdType == PimCmdEnum::BIT_SLICE_INSERT) {
+        numberOfALUOperationPerElement *= 5; // 2 shifts, 1 not, 1 and, 1 or
+      }
+      msRuntime = (maxElementsPerRegion * m_fulcrumAluLatency * numberOfALUOperationPerElement) * (numPass - 1);
+      msRuntime += (minElementPerRegion * m_fulcrumAluLatency * numberOfALUOperationPerElement);
+      msRuntime += m_tR + m_tW;
+      double energyLogical = ((maxElementsPerRegion - 1) * 2 *  m_fulcrumShiftEnergy) + ((maxElementsPerRegion) * m_fulcrumALULogicalEnergy * numberOfALUOperationPerElement);
+      mjEnergy = (energyLogical + m_eAP) * numCores * numPass;
+      mjEnergy += m_pBChip * m_numChipsPerRank * m_numRanks * msRuntime;
+      break;
+    }
     case PimCmdEnum::ADD_SCALAR:
     case PimCmdEnum::SUB_SCALAR:
     case PimCmdEnum::MUL_SCALAR:

--- a/libpimeval/src/pimSim.cpp
+++ b/libpimeval/src/pimSim.cpp
@@ -763,6 +763,26 @@ pimSim::pimRedSum(PimObjId src, void* sum, uint64_t idxBegin, uint64_t idxEnd)
   return m_device->executeCmd(std::move(cmd));
 }
 
+//! @brief  Extract a bit slice from a data vector. Dest must be BOOL type
+bool
+pimSim::pimBitSliceExtract(PimObjId src, PimObjId destBool, unsigned bitIdx)
+{
+  pimPerfMon perfMon("pimBitSliceExtract");
+  if (!isValidDevice()) { return false; }
+  std::unique_ptr<pimCmd> cmd = std::make_unique<pimCmdFunc1>(PimCmdEnum::BIT_SLICE_EXTRACT, src, destBool, bitIdx);
+  return m_device->executeCmd(std::move(cmd));
+}
+
+//! @brief  Insert a bit slice to a data vector. Src must be BOOL type
+bool
+pimSim::pimBitSliceInsert(PimObjId srcBool, PimObjId dest, unsigned bitIdx)
+{
+  pimPerfMon perfMon("pimBitSliceInsert");
+  if (!isValidDevice()) { return false; }
+  std::unique_ptr<pimCmd> cmd = std::make_unique<pimCmdFunc1>(PimCmdEnum::BIT_SLICE_INSERT, srcBool, dest, bitIdx);
+  return m_device->executeCmd(std::move(cmd));
+}
+
 bool
 pimSim::pimRotateElementsRight(PimObjId src)
 {

--- a/libpimeval/src/pimSim.h
+++ b/libpimeval/src/pimSim.h
@@ -110,6 +110,8 @@ public:
   bool pimRedSum(PimObjId src, void* sum, uint64_t idxBegin = 0, uint64_t idxEnd = 0);
   bool pimRedMin(PimObjId src, void* min, uint64_t idxBegin = 0, uint64_t idxEnd = 0);
   bool pimRedMax(PimObjId src, void* max, uint64_t idxBegin = 0, uint64_t idxEnd = 0);
+  bool pimBitSliceExtract(PimObjId src, PimObjId destBool, unsigned bitIdx);
+  bool pimBitSliceInsert(PimObjId srcBool, PimObjId dest, unsigned bitIdx);
   template <typename T> bool pimBroadcast(PimObjId dest, T value);
   bool pimRotateElementsRight(PimObjId src);
   bool pimRotateElementsLeft(PimObjId src);

--- a/tests/test-bit-slice/Makefile
+++ b/tests/test-bit-slice/Makefile
@@ -1,0 +1,19 @@
+# Makefile: Test PIM bit slice operations
+# Copyright (c) 2024 University of Virginia
+# This file is licensed under the MIT License.
+# See the LICENSE file in the root of this repository for more details.
+
+PROJ_ROOT = ../..
+include ${PROJ_ROOT}/Makefile.common
+
+EXEC := test-bit-slice.out
+SRC := test-bit-slice.cpp
+
+debug perf dramsim3_integ: $(EXEC)
+
+$(EXEC): $(SRC) $(DEPS)
+	$(CXX) $< $(CXXFLAGS) -o $@
+
+clean:
+	rm -rf $(EXEC) *.dSYM
+

--- a/tests/test-bit-slice/test-bit-slice.cpp
+++ b/tests/test-bit-slice/test-bit-slice.cpp
@@ -1,0 +1,119 @@
+// Test: Test PIM bit slice operations
+// Copyright (c) 2024 University of Virginia
+// This file is licensed under the MIT License.
+// See the LICENSE file in the root of this repository for more details.
+
+#include "libpimeval.h"
+#include <iostream>
+#include <vector>
+#include <algorithm>
+#include <bitset>
+#include <cassert>
+#include <cstdlib>
+#include <cstdio>
+
+
+bool testBitSlice(PimDeviceEnum deviceType, bool runArithmetic)
+{
+  // 1GB capacity
+  unsigned numRanks = 1;
+  unsigned numBankPerRank = 1;
+  unsigned numSubarrayPerBank = 4;
+  unsigned numRows = 1024;
+  unsigned numCols = 8192;
+
+  uint64_t numElements = 16 * 1024;
+
+  std::vector<int> src1(numElements);
+  std::vector<int> src2(numElements);
+  std::vector<int> dest(numElements);
+
+  for (uint64_t i = 0; i < numElements; ++i) {
+    src1[i] = static_cast<int>(i);
+    src2[i] = static_cast<int>(i + 1);
+  }
+
+  PimStatus status = pimCreateDevice(deviceType, numRanks, numBankPerRank, numSubarrayPerBank, numRows, numCols);
+  assert(status == PIM_OK);
+
+  // allocate src1/2, dest, and bit slice objects
+  PimObjId objSrc1 = pimAlloc(PIM_ALLOC_AUTO, numElements, PIM_INT32);
+  PimObjId objSrc2 = pimAllocAssociated(objSrc1, PIM_INT32);
+  PimObjId objDest = pimAllocAssociated(objSrc1, PIM_INT32);
+  PimObjId objBool1 = pimAllocAssociated(objSrc1, PIM_BOOL);  // padding
+  PimObjId objBool2 = pimAllocAssociated(objSrc1, PIM_BOOL);  // padding
+  PimObjId objBool3 = pimAllocAssociated(objSrc1, PIM_BOOL);  // padding
+  PimObjId objBool4 = pimAllocAssociated(objSrc1, PIM_BOOL);  // padding
+  assert(objSrc1 != -1 && objSrc2 != -1 && objDest != -1);
+  assert(objBool1 != -1 && objBool2 != -1 && objBool3 != -1 && objBool4 != -1);
+
+  // copy host to device
+  status = pimCopyHostToDevice((void*)src1.data(), objSrc1);
+  assert(status == PIM_OK);
+  status = pimCopyHostToDevice((void*)src2.data(), objSrc2);
+  assert(status == PIM_OK);
+
+  // Performe functional bit-serial int32 addition using bit-slice APIs
+  if (runArithmetic) {
+    status = pimAdd(objSrc1, objSrc2, objDest);
+    assert(status == PIM_OK);
+  } else {
+    status = pimBroadcastUInt(objBool3, 0); // carry
+    assert(status == PIM_OK);
+    for (unsigned i = 0; i < 32; i++) {
+      // SUM = A XOR B XOR CIN
+      status = pimBitSliceExtract(objSrc1, objBool1, i);  assert(status == PIM_OK);
+      status = pimBitSliceExtract(objSrc2, objBool2, i);  assert(status == PIM_OK);
+      status = pimXor(objBool1, objBool2, objBool4);      assert(status == PIM_OK);
+      status = pimXor(objBool3, objBool4, objBool4);      assert(status == PIM_OK);
+      status = pimBitSliceInsert(objBool4, objDest, i);   assert(status == PIM_OK);
+      // COUT = (A AND B) OR (A AND CIN)
+      status = pimAnd(objBool1, objBool2, objBool3);      assert(status == PIM_OK);
+      status = pimAnd(objBool1, objBool2, objBool4);      assert(status == PIM_OK);
+      status = pimOr(objBool3, objBool4, objBool3);       assert(status == PIM_OK);
+    }
+  }
+
+  status = pimCopyDeviceToHost(objDest, (void*)dest.data());
+  assert(status == PIM_OK);
+
+  bool ok = true;
+  for (uint64_t i = 0; i < numElements; ++i) {
+    if (dest[i] != src1[i] + src2[i]) {
+      ok = false;
+      std::printf("Bit-slice Test Error: src1 0x%x src2 0x%x dest 0x%x\n", src1[i], src2[i], dest[i]);
+    }
+  }
+
+  pimFree(objSrc1);
+  pimFree(objSrc2);
+  pimFree(objDest);
+  pimFree(objBool1);
+  pimFree(objBool2);
+  pimFree(objBool3);
+  pimFree(objBool4);
+
+  pimShowStats();
+  pimResetStats();
+  pimDeleteDevice();
+
+  std::cout << "Bit-slice Test " << (ok ? "PASSED" : "FAILED") << std::endl;
+  return ok;
+}
+
+int main()
+{
+  std::cout << "PIM Regression Test: PIM bit slice operations" << std::endl;
+
+  bool ok = true;
+  ok &= testBitSlice(PIM_DEVICE_BITSIMD_V, false);
+  ok &= testBitSlice(PIM_DEVICE_FULCRUM, false);
+  ok &= testBitSlice(PIM_DEVICE_BANK_LEVEL, false);
+  ok &= testBitSlice(PIM_DEVICE_BITSIMD_V, true);
+  ok &= testBitSlice(PIM_DEVICE_FULCRUM, true);
+  ok &= testBitSlice(PIM_DEVICE_BANK_LEVEL, true);
+
+  std::cout << (ok ? "PASSED" : "FAILED") << std::endl;
+  return 0;
+}
+


### PR DESCRIPTION
Main changes:
- Add new pimBitSliceExtract and pimBitSliceInsert operations
- Update performance and energy calculation of the two operations for bit-serial, fulcrum, and bank-level PIM
- Add a test-bit-slice application to exercise bit-slice and Boolean operations

Prerequisite features:
- Associated allocation for mixed data types, H-layout data padding, and bit-width handling
- PIM_BOOL data type support
- Mixed data type operation support: bit-slice extract dest and bit-slice insert src must be PIM_BOOL

Resolves Issue #28. Thanks for review.