### PR TITLE
Retire -DDEBUG macro; Switch to env var based debug flags.

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -23,7 +23,7 @@ ifeq ($(MAKECMDGOALS),)
 	MAKECMDGOALS := $(.DEFAULT_GOAL)
 endif
 ifeq ($(MAKECMDGOALS),debug)
-	CXXFLAGS += -g -DDEBUG
+	CXXFLAGS += -g
 endif
 ifeq ($(MAKECMDGOALS),perf)
 	CXXFLAGS += -O3 -Wno-unknown-pragmas

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ PIMeval-PIMbench/
 ### How To Build
 * Run `make` at root directory or subdirectories
   * `make perf`: Build with `-O3` for performance measurement (default)
-  * `make debug`: Build with `-g` and `-DDEBUG` for debugging and printing verbose messages
+  * `make debug`: Build with `-g` for debugging
 * Multi-threaded building
   * `make -j<n_proc>`
 * Specify simulation target

--- a/libpimeval/Makefile
+++ b/libpimeval/Makefile
@@ -31,7 +31,7 @@ ifeq ($(MAKECMDGOALS),)
 endif
 
 ifeq ($(MAKECMDGOALS),debug)
-	CXXFLAGS += $(CXXFLAGS_DEBUG) -DDEBUG
+	CXXFLAGS += $(CXXFLAGS_DEBUG)
 endif
 
 ifeq ($(MAKECMDGOALS),perf)

--- a/libpimeval/src/pimCmd.h
+++ b/libpimeval/src/pimCmd.h
@@ -106,7 +106,7 @@ enum class PimCmdEnum {
 class pimCmd
 {
 public:
-  pimCmd(PimCmdEnum cmdType) : m_cmdType(cmdType) {}
+  pimCmd(PimCmdEnum cmdType);
   virtual ~pimCmd() {}
 
   void setDevice(pimDevice* device) { m_device = device; }
@@ -153,6 +153,7 @@ protected:
 
   PimCmdEnum m_cmdType;
   pimDevice* m_device = nullptr;
+  bool m_debugCmds;
 
   //! @class  pimCmd::regionWorker
   //! @brief  Thread worker to process regions in parallel

--- a/libpimeval/src/pimSim.h
+++ b/libpimeval/src/pimSim.h
@@ -43,6 +43,7 @@ public:
   unsigned getNumColPerSubarray() const { return m_config.getNumColPerSubarray(); }
   bool isAnalysisMode() const { return m_config.isAnalysisMode(); }
   unsigned getNumThreads() const { return m_config.getNumThreads(); }
+  bool isDebug(pimSimConfig::pimDebugFlags flag) const { return m_config.getDebug() & flag; }
 
   unsigned getNumCores() const;
   unsigned getNumRows() const;

--- a/libpimeval/src/pimSimConfig.h
+++ b/libpimeval/src/pimSimConfig.h
@@ -99,6 +99,7 @@ public:
     DEBUG_API_CALLS   = 0x0002,
     DEBUG_CMDS        = 0x0004,
     DEBUG_ALLOC       = 0x0008,
+    DEBUG_PERF        = 0x0010,
   };
 
 private:

--- a/libpimeval/src/pimStats.cpp
+++ b/libpimeval/src/pimStats.cpp
@@ -19,9 +19,9 @@ void
 pimStatsMgr::showStats() const
 {
   std::printf("----------------------------------------\n");
-  #if defined(DEBUG)
-  showApiStats();
-  #endif
+  if (pimSim::get()->isDebug(pimSimConfig::DEBUG_API_CALLS)) {
+    showApiStats();
+  }
   showDeviceParams();
   showCopyStats();
   showCmdStats();
@@ -92,9 +92,9 @@ pimStatsMgr::showDeviceParams() const
   std::printf(" %30s : %f\n", "Row Read (ns)", paramsDram.getNsRowRead());
   std::printf(" %30s : %f\n", "Row Write (ns)", paramsDram.getNsRowWrite());
   std::printf(" %30s : %f\n", "tCCD (ns)", paramsDram.getNsTCCD_S());
-  #if defined(DEBUG)
-  std::printf(" %30s : %f\n", "AAP (ns)", paramsDram.getNsAAP());
-  #endif
+  if (pimSim::get()->isDebug(pimSimConfig::DEBUG_PERF)) {
+    std::printf(" %30s : %f\n", "AAP (ns)", paramsDram.getNsAAP());
+  }
 }
 
 //! @brief  Show data copy stats


### PR DESCRIPTION
It's more convenient to use PIMEVAL_DEBUG env variable to toggle debug messages in categories, which avoids recompilation.

This is safe to merge. No simulator behavior impact.