### PR TITLE
Add missing header in ./misc-bench/softmax-batch/softmax-batch.cpp

### DIFF
--- a/misc-bench/softmax-batch/softmax-batch.cpp
+++ b/misc-bench/softmax-batch/softmax-batch.cpp
@@ -8,6 +8,7 @@
 #include <vector>
 #include <getopt.h>
 #include <cmath>
+#include <algorithm>
 #include "util.h"
 
 using namespace std;


### PR DESCRIPTION
The missing of a header in this file will cause the following compiler error:

```
softmax-batch.cpp: In function ‘void softmaxOnHost(const std::vector<int>&, std::vector<int>&)’:
softmax-batch.cpp:174:27: error: ‘max_element’ is not a member of ‘std’; did you mean ‘tuple_element’?
  174 |     int max_input = *std::max_element(input.begin(), input.end());
      |                           ^~~~~~~~~~~
      |                           tuple_element
```
This PR solved this problem by simply add the missing header file.

Here is my system info:
```
OS: Linux 6.16.8-arch3-1 #1 SMP PREEMPT_DYNAMIC Mon, 22 Sep 2025 22:08:35 +0000 x86_64 GNU/Linux
g++:  15.2.1 20250813
```