### PR TITLE
Fix make command from root

### DIFF
--- a/misc-bench/hamming-string-match/hamming-data-generator/Makefile
+++ b/misc-bench/hamming-string-match/hamming-data-generator/Makefile
@@ -24,9 +24,9 @@ ifeq ($(USE_OPENMP),1)
 	CXXFLAGS += -fopenmp
 endif
 
-.PHONY: all clean
+.PHONY: all clean debug perf dramsim3_integ
 
-all: $(EXEC)
+all debug perf dramsim3_integ: $(EXEC)
 
 # Note: Need to avoid feeding .h files to clang command line
 $(EXEC): $(SRC_FILES) $(HEADER_DEPS)

--- a/misc-bench/string-match/data-generator/Makefile
+++ b/misc-bench/string-match/data-generator/Makefile
@@ -24,9 +24,9 @@ ifeq ($(USE_OPENMP),1)
 	CXXFLAGS += -fopenmp
 endif
 
-.PHONY: all clean
+.PHONY: all clean debug perf dramsim3_integ
 
-all: $(EXEC)
+all debug perf dramsim3_integ: $(EXEC)
 
 # Note: Need to avoid feeding .h files to clang command line
 $(EXEC): $(SRC_FILES) $(HEADER_DEPS)


### PR DESCRIPTION
Previously, `make debug` from the root directory failed as the string matching data generators did not have this Makefile target. This PR adds the targets `debug`, `perf`, and `dramsim3_integ`, to both data generator Makefiles, sets them to make the data generator, and declares them as phony.