### PR TITLE
Fix incorrect placement of tot rows sum

### DIFF
--- a/libpimeval/src/pimResMgr.cpp
+++ b/libpimeval/src/pimResMgr.cpp
@@ -793,6 +793,7 @@ pimResMgr::coreUsage::findAvailRange(unsigned numRowsToAlloc)
 void
 pimResMgr::coreUsage::addRange(std::pair<unsigned, unsigned> range, PimObjId objId)
 {
+  m_totRowsInUse += range.second;
   // aggregate with the prev range
   if (!m_rangesInUse.empty()) {
     auto it = std::prev(m_rangesInUse.end());
@@ -807,7 +808,6 @@ pimResMgr::coreUsage::addRange(std::pair<unsigned, unsigned> range, PimObjId obj
   }
   m_rangesInUse.insert(std::make_pair(range, objId));
   m_newAlloc.insert(range);
-  m_totRowsInUse += range.second;
 }
 
 //! @brief  Delete an object from core usage


### PR DESCRIPTION
Currently, pimAlloc does not update `m_totRowsInUse` correctly. If a region is aggregated with another region, then the number of rows in the new region is added to the total rows, but the rows in the original region are not subtracted, and thus double counted.

This PR fixes the above by adding the number of new rows to `m_totRowsInUse` before aggregating regions.